### PR TITLE
ci: remove builder for android

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        os: [win, macos, linux, android]
+        os: [win, macos, linux]
         arch: [aarch64, x86_64]
       fail-fast: false
 


### PR DESCRIPTION
只删除了构建标志，但保留原有的处理逻辑。
为了以防万一真的有人用Android pc。