### PR TITLE
fix: Language `tree` is not included in this bundle.

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -60,7 +60,7 @@ cd narutomobile
 
 ## 4. 下载 OCR（文字识别）资源文件 [ppocr_v6.zip](https://download.maafw.xyz/MaaCommonAssets/OCR/ppocr_v6/ppocr_v6-small.zip) 解压到 `assets/resource/model/ocr/` 目录下，确保路径如下：
 
-```tree
+```bash
    assets/resource/model/ocr/
    ├── det.onnx
    ├── keys.txt


### PR DESCRIPTION
文档站的构建炸了