### PR TITLE
fix:清周胜过期宝箱改为每赢一局清理一次

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -3764,7 +3764,7 @@
             ]
         },
         "清周胜过期宝箱": {
-            "description": "清周胜过期宝箱要有时间卡,会先打完周胜胜利次数再开始清理过期宝箱",
+            "description": "清周胜过期宝箱要有时间卡;每赢一局后会先领取并清理过期宝箱,再继续战斗",
             "type": "switch",
             "cases": [
                 {
@@ -3773,10 +3773,11 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {
-                        "weekly_win_stop": {
+                        "win_counter": {
                             "next": [
                                 "weekly_win_duel_mission",
-                                "back_main_screen_and_stop"
+                                "go_to_war_again",
+                                "weekly_win_stop"
                             ]
                         },
                         "weekly_win_get_weekly_duel_mission_award_2_end": {
@@ -3796,7 +3797,23 @@
                         "weekly_win_check_no_daily_duel_mission_award": {
                             "next": [
                                 "weekly_win_check_daily_duel_mission_recover_award",
-                                "back_main_screen_and_stop"
+                                "weekly_win_check_daily_duel_mission_back_fight"
+                            ]
+                        },
+                        "weekly_win_check_daily_duel_mission_without_recover_award": {
+                            "next": [
+                                "weekly_win_check_daily_duel_mission_back_fight"
+                            ]
+                        },
+                        "weekly_win_check_daily_duel_mission_without_time_card": {
+                            "next": [
+                                "weekly_win_check_daily_duel_mission_back_fight"
+                            ]
+                        },
+                        "weekly_win_check_daily_duel_mission_back_fight": {
+                            "next": [
+                                "go_to_war_again",
+                                "weekly_win_stop"
                             ]
                         }
                     }

--- a/assets/resource/base/pipeline/Weekly_win.json
+++ b/assets/resource/base/pipeline/Weekly_win.json
@@ -275,6 +275,9 @@
         },
         "pre_delay": 0,
         "post_delay": 0,
+        "next": [
+            "go_to_war"
+        ],
         "focus": "再来一把！",
         "$doc": "JumpBack to 'go_to_war'"
     },


### PR DESCRIPTION
之前的逻辑是打完指定胜利次数后再领取宝箱，这样会导致过期的首胜宝箱无法及时领取。稍微改了一下逻辑，赢一把清一把，这样周胜打完的时候过期的宝箱也全部领完了。