### PR TITLE
build(deps): upgrade maafw and mfaa versions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,8 +1,8 @@
 name: install
 
 env:
-  MFAA_VERSION: v2.12.1
-  MAA_FRAMEWORK_VERSION: v5.12.1
+  MFAA_VERSION: v2.15.2
+  MAA_FRAMEWORK_VERSION: v5.12.3
 
 on:
   push:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "json-with-comments>=1.2.10",
     "loguru>=0.7.3",
-    "maafw>=5.12.1",
+    "maafw>=5.12.3",
     "notify-py>=0.3.2",
     "opencv-python>=5.0.0.93",
     "pillow>=12.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 json-with-comments==1.2.10
 loguru==0.7.3
 maaagentbinary==1.0.1
-maafw==5.12.1
+maafw==5.12.3
 numpy==2.3.5  
 pillow==12.0.0
 strenum==0.4.15      

--- a/tools/install_dev.py
+++ b/tools/install_dev.py
@@ -19,7 +19,7 @@ from ci.install import (
 )
 from utils import download
 
-DEFAULT_MFA_VERSION = "v2.12.1"
+DEFAULT_MFA_VERSION = "v2.15.2"
 GHPROXY_URL = "https://gh-proxy.natsuu.top/"
 
 parser = argparse.ArgumentParser(description="Install MaaFramework to install directory")

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "json-with-comments", specifier = ">=1.2.10" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "maafw", specifier = ">=5.12.1" },
+    { name = "maafw", specifier = ">=5.12.3" },
     { name = "notify-py", specifier = ">=0.3.2" },
     { name = "opencv-python", specifier = ">=5.0.0.93" },
     { name = "pillow", specifier = ">=12.0.0" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "maafw"
-version = "5.12.1"
+version = "5.12.3"
 source = { registry = "https://mirrors.cloud.tencent.com/pypi/simple" }
 dependencies = [
     { name = "maaagentbinary" },
@@ -108,12 +108,12 @@ dependencies = [
     { name = "strenum" },
 ]
 wheels = [
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/51/09/da3fd66055c4c52f8343ffddf5590236a5f2e1461c3dfdc2504099fd71d6/maafw-5.12.1-py3-none-macosx_13_0_arm64.whl", hash = "sha256:8caffa0389389eb6fffe4d31c33c14a863a52875d096e70414de8936dd91c3cc" },
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/18/85/9d28867356c3d7f6ca7dc6a8ca102a467820ed296d6e79f4e41413e1a693/maafw-5.12.1-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:68b8dcd70028428549264f9f4350027a26b47ddb31e8998e40df80cdf78028d7" },
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/06/d6/68cedd88e60bc3835fa0463fb3d43a095fead0ac284204f9c80285985927/maafw-5.12.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:42b56f4c0fa195424d78e53df75b6a8aee8d9cba4241f5c47bce7496eea5c8a8" },
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/92/71/c627676f0d6dba7cc98fbd0f068434b51615e9a9e4487c10e6a5a74e80cf/maafw-5.12.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f52870433e3eb7a6355992edb2d7c09f01b6b87232db9e58ba15aae3be3d02f0" },
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/76/42/07a27fdf4d3df5236069e9c82e16c5341ae805ba4a084f5870dfe29aaf21/maafw-5.12.1-py3-none-win_amd64.whl", hash = "sha256:918697fdca796f0cb5753ac2c08155d4ecfe64f4e380b57b0479bb506f62a118" },
-    { url = "https://mirrors.cloud.tencent.com/pypi/packages/61/74/c742125fa084ce923c2627243503f6f746180de25c4816ad38d77bda8fa7/maafw-5.12.1-py3-none-win_arm64.whl", hash = "sha256:c2a8ddf7a24e063aa54b19d1d2eaf52702a8cde2b30d71447a42f6c234bec2a3" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/dd/ce/cfa1504c98fdc55074449df8ecd5d81b5cb5f81d748ecc5038cee8e63725/maafw-5.12.3-py3-none-macosx_13_0_arm64.whl", hash = "sha256:8d2ca1eb4e75988adf51e798079bf3894a1759e10770b84668f5e79cf40f3fae" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/3b/31/08f28824ea89d8eaf702f416ccfd217256d488fec3c8e7254f32e12b5c4c/maafw-5.12.3-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:4860afaba6cca73c646aa66d04bbfaccc46574e6a5cf9e2c75a9ee23f0c50d9a" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/1c/d6/8e31234ca2fe430ed317a5418329297e60df33ff47de7c82fccf4f9cdbe7/maafw-5.12.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6c2c6af0f99508d0cce13d2c041f10813576158eb567a68225d908fffb34897f" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/9b/a3/38b92640fdff4d3a48a1ab11aa567256dccb78f8197c740f3fd62af0448d/maafw-5.12.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:b6aef9d98b0fd8f14f34e3f6f21230bd5abe8cddeeb254975fd889475f2e94e0" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/73/b4/e0814b83b542424752718d60802e4a753ed4d1951531bbe3faecb5125b5d/maafw-5.12.3-py3-none-win_amd64.whl", hash = "sha256:91d24bcac59fe39392fc8c56ffa50e5d8c88130da8f10c9b8d003521f592854c" },
+    { url = "https://mirrors.cloud.tencent.com/pypi/packages/c3/ad/898526ac489dd93954134c778bfd206e9a76e9aa071d87a431fafe217ba3/maafw-5.12.3-py3-none-win_arm64.whl", hash = "sha256:a8ac1afc3832205e809460210b382a79525f1573d9503fa73ad425a759f28116" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update dependency versions for `maafw` and `mfaa` across the project configuration and installation tools:

- Bump `maafw` from 5.12.1 to 5.12.3 in `pyproject.toml` and `requirements.txt`
- Bump `MFAA_VERSION` to v2.15.2 in `.github/workflows/install.yml` and `tools/install_dev.py`
- Bump `MAA_FRAMEWORK_VERSION` to v5.12.3 in `.github/workflows/install.yml`