### PR TITLE
feat: 接入 MaaFwApp Android 客户端

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,107 @@
+name: android-release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: android-release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+          cache-dependency-path: Android/MaaFwApp/gradle/wrapper/gradle-wrapper.properties
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Cache MaaFramework and agent core
+        uses: actions/cache@v4
+        with:
+          path: |
+            Android/MaaFwApp/.maa-cache
+            Android/MaaFwApp/.maafw
+          key: android-native-${{ runner.os }}-fw5.12.3-core3.13.15-all
+          restore-keys: |
+            android-native-${{ runner.os }}-fw5.12.3-core3.13.15-
+            android-native-${{ runner.os }}-
+
+      - name: Write local.properties
+        run: |
+          {
+            echo "sdk.dir=${ANDROID_SDK_ROOT}"
+            echo "pi.profile=../profile.yaml"
+          } > Android/MaaFwApp/local.properties
+
+      - name: Prepare PI tree
+        run: python tools/prepare_android_pi.py
+
+      - name: Fetch MaaFramework native libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python Android/MaaFwApp/scripts/setup_maa_framework.py --tag v5.12.3
+
+      - name: Pack agent runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
+            --requirements requirements.txt \
+            --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
+            --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
+
+      - name: Decode keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "ANDROID_KEYSTORE_BASE64 is empty; assembleRelease will be unsigned"
+            exit 0
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+          echo "KEYSTORE_PATH=$RUNNER_TEMP/release.jks" >> "$GITHUB_ENV"
+
+      - name: Assemble release APK
+        working-directory: Android/MaaFwApp
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          chmod +x gradlew
+          ./gradlew --no-daemon :app:assembleRelease
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: MaaAutoNaruto-android-release-${{ github.ref_name }}
+          path: |
+            Android/MaaFwApp/app/build/outputs/apk/release/*.apk
+            Android/MaaFwApp/app/build/outputs/mapping/release/mapping.txt
+          if-no-files-found: error
+
+      - uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: Android/MaaFwApp/app/build/outputs/apk/release/*.apk
+          fail_on_unmatched_files: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,100 @@
+name: android
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/android.yml"
+      - "Android/**"
+      - "tools/prepare_android_pi.py"
+      - "assets/**"
+      - "agent/**"
+      - "requirements.txt"
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/android.yml"
+      - "Android/**"
+      - "tools/prepare_android_pi.py"
+      - "assets/**"
+      - "agent/**"
+      - "requirements.txt"
+  workflow_dispatch:
+
+concurrency:
+  group: android-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+          cache-dependency-path: Android/MaaFwApp/gradle/wrapper/gradle-wrapper.properties
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Cache MaaFramework and agent core
+        uses: actions/cache@v4
+        with:
+          path: |
+            Android/MaaFwApp/.maa-cache
+            Android/MaaFwApp/.maafw
+          key: android-native-${{ runner.os }}-fw5.12.3-core3.13.15-arm64
+          restore-keys: |
+            android-native-${{ runner.os }}-
+
+      - name: Write local.properties
+        run: |
+          {
+            echo "sdk.dir=${ANDROID_SDK_ROOT}"
+            echo "pi.profile=../profile.yaml"
+            echo "build.debugAbi=arm64-v8a"
+          } > Android/MaaFwApp/local.properties
+
+      - name: Prepare PI tree
+        run: python tools/prepare_android_pi.py
+
+      - name: Fetch MaaFramework native libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a --tag v5.12.3
+
+      - name: Pack agent runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
+            --requirements requirements.txt \
+            --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
+            --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
+
+      - name: Assemble debug APK
+        working-directory: Android/MaaFwApp
+        run: |
+          chmod +x gradlew
+          ./gradlew --no-daemon :app:assembleDebug
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: MaaAutoNaruto-android-arm64-${{ github.sha }}
+          path: Android/MaaFwApp/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -469,6 +469,10 @@ install/debug/maa.log
 .nicegui/storage-general.json
 .venv
 
+# MaaFwApp 打包中间产物
+Android/pi-root/
+Android/agent-dist/
+
 config
 assets/resource/model/ocr
 assets/resource/base/model/ocr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Android/MaaFwApp"]
+	path = Android/MaaFwApp
+	url = https://github.com/Aliothmoon/MaaFwApp.git

--- a/Android/README.md
+++ b/Android/README.md
@@ -8,7 +8,7 @@
 ```bash
 git submodule update --init Android/MaaFwApp
 python tools/prepare_android_pi.py
-python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a
+python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a --tag v5.12.3
 python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
     --requirements requirements.txt \
     --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
@@ -33,11 +33,22 @@ python tools/prepare_android_pi.py
 
 # 已连接设备
 ./Android/MaaFwApp/gradlew.bat -p Android/MaaFwApp :app:installDebug
+
+# 正式包：release 固定打 arm64-v8a + x86_64，so 也要两个 ABI
+python Android/MaaFwApp/scripts/setup_maa_framework.py --tag v5.12.3
+./Android/MaaFwApp/gradlew.bat -p Android/MaaFwApp :app:assembleRelease
 ```
 
 包名是 `com.aliothmoon.maafw.maanaruto`。桌面端的 `child_exec` 不参与，解释器是配方里的 `bin/python3`。
 
-CI：`.github/workflows/android.yml` 按上面那套打 debug 包，APK 挂在 Actions artifact 上。
+签名读环境变量，缺了就打未签名包：`KEYSTORE_PATH`、`KEYSTORE_PASSWORD`、`KEY_ALIAS`、`KEY_PASSWORD`。也可写进子模块的 `local.properties`，环境变量优先。
+
+CI：
+
+- `.github/workflows/android.yml`：改相关路径就打 debug 包
+- `.github/workflows/android-release.yml`：打 `v*` 或手动触发时打 release；有签名 secrets 就签名，APK 挂 artifact，tag 还会附到 GitHub Release
+
+仓库 Secrets（release）：`ANDROID_KEYSTORE_BASE64`（keystore 的 base64）、`KEYSTORE_PASSWORD`、`KEY_ALIAS`、`KEY_PASSWORD`。
 
 `pi-root/` 和 `agent-dist/` 不进 git。升外壳：
 

--- a/Android/README.md
+++ b/Android/README.md
@@ -1,0 +1,46 @@
+# Android 客户端
+
+外壳是 [MaaFwApp](https://github.com/Aliothmoon/MaaFwApp) 子模块，和本仓库的开发用 MaaFwApp 不是同一份。
+`interface.json` 在 `assets/`，agent 在仓库根，Gradle 只能从一个目录 include，所以先摊成 `Android/pi-root/`。
+
+## 首次
+
+```bash
+git submodule update --init Android/MaaFwApp
+python tools/prepare_android_pi.py
+python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a
+python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
+    --requirements requirements.txt \
+    --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
+    --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
+```
+
+`prepare_android_pi.py` 会顺带拉 OCR（`tools/ci/configure.py`），没有模型识别会空转。
+
+在 `Android/MaaFwApp/local.properties` 里写（子模块自己的，不进 git）：
+
+```properties
+sdk.dir=<Android SDK>
+pi.profile=../profile.yaml
+build.debugAbi=arm64-v8a
+```
+
+## 出包
+
+```bash
+# 改了 assets / agent 源码
+python tools/prepare_android_pi.py
+
+# 已连接设备
+./Android/MaaFwApp/gradlew.bat -p Android/MaaFwApp :app:installDebug
+```
+
+包名是 `com.aliothmoon.maafw.maanaruto`。桌面端的 `child_exec` 不参与，解释器是配方里的 `bin/python3`。
+
+`pi-root/` 和 `agent-dist/` 不进 git。升外壳：
+
+```bash
+git -C Android/MaaFwApp fetch
+git -C Android/MaaFwApp checkout origin/main
+git add Android/MaaFwApp
+```

--- a/Android/README.md
+++ b/Android/README.md
@@ -37,6 +37,8 @@ python tools/prepare_android_pi.py
 
 包名是 `com.aliothmoon.maafw.maanaruto`。桌面端的 `child_exec` 不参与，解释器是配方里的 `bin/python3`。
 
+CI：`.github/workflows/android.yml` 按上面那套打 debug 包，APK 挂在 Actions artifact 上。
+
 `pi-root/` 和 `agent-dist/` 不进 git。升外壳：
 
 ```bash

--- a/Android/profile.yaml
+++ b/Android/profile.yaml
@@ -1,0 +1,40 @@
+# MaaFwApp 打包配方。相对路径相对本文件。
+# 先跑：python tools/prepare_android_pi.py
+# agent 运行时：见 README 里的 build_agent_bundle.py
+
+assets: pi-root
+
+include:
+  - interface.json
+  - resource/**
+  - agent/**
+  - docs/imgs/logo.png
+  - CONTACT
+  - LICENSE
+
+# announcement 的 md 只给桌面端看；识别用的图和模型都在 resource/base 里，别挖
+exclude:
+  - resource/announcement/*.md
+
+# 出运行时（内核下到 Android/MaaFwApp/.maafw/，不用 NDK）：
+#   python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
+#     --requirements requirements.txt \
+#     --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
+#     --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
+agent:
+  sourceDir: agent-dist
+  abi: [arm64-v8a]
+  runtimes:
+    - location: bundle
+      executable: bin/python3
+      args: [-u, agent/main.py]
+      env:
+        PYTHONHOME: "{bundle}/prefix"
+        PYTHONPATH: "{bundle}/site-packages/pure.zip:{bundle}/site-packages"
+        LD_LIBRARY_PATH: "{bundle}/prefix/lib:{bundle}/site-packages/chaquopy/lib:{nativeLibs}"
+        MAAFW_BINARY_PATH: "{nativeLibs}"
+
+app:
+  id: maanaruto
+  label: MaaAutoNaruto
+  icon: ../docs/imgs/logo.png

--- a/tools/prepare_android_pi.py
+++ b/tools/prepare_android_pi.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""把仓库里的 assets + agent 合成 MaaFwApp 能 sync 的一份 PI 根。
+
+interface.json 在 assets/，agent 在仓库根。Gradle 的 include 只能相对 assets 目录，
+所以先摊到 Android/pi-root/：根上是 interface.json，旁边是 agent/。
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DEST = REPO / "Android" / "pi-root"
+IGNORE = shutil.ignore_patterns("__pycache__", "*.pyc", ".git")
+
+
+def copy_tree(src: Path, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest, ignore=IGNORE)
+
+
+def main() -> int:
+    assets = REPO / "assets"
+    if not (assets / "interface.json").is_file():
+        print(f"missing {assets / 'interface.json'}", file=sys.stderr)
+        return 1
+
+    sys.path.insert(0, str(REPO / "tools" / "ci"))
+    from configure import configure_ocr_model
+
+    configure_ocr_model()
+
+    if DEST.exists():
+        shutil.rmtree(DEST)
+    DEST.mkdir(parents=True)
+
+    for child in assets.iterdir():
+        target = DEST / child.name
+        if child.is_dir():
+            copy_tree(child, target)
+        else:
+            shutil.copy2(child, target)
+
+    copy_tree(REPO / "agent", DEST / "agent")
+
+    for name in ("LICENSE", "CONTACT"):
+        src = REPO / name
+        if src.is_file():
+            shutil.copy2(src, DEST / name)
+
+    logo_ico = REPO / "docs" / "imgs" / "logo.ico"
+    if logo_ico.is_file():
+        (DEST / "resource").mkdir(exist_ok=True)
+        shutil.copy2(logo_ico, DEST / "resource" / "logo.ico")
+
+    logo_png = REPO / "docs" / "imgs" / "logo.png"
+    if logo_png.is_file():
+        dest_logo = DEST / "docs" / "imgs"
+        dest_logo.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(logo_png, dest_logo / "logo.png")
+
+    files = sum(1 for p in DEST.rglob("*") if p.is_file())
+    print(f"{files} files -> {DEST}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
把 [MaaFwApp](https://github.com/Aliothmoon/MaaFwApp) 接到本仓库，作为 Android 客户端GUI
## 布局

- `Android/MaaFwApp`：外壳子模块（当前 `ada2156`）
- `Android/profile.yaml`：打包配方（包名后缀 `maanaruto`）
- `tools/prepare_android_pi.py`：把 `assets/` + `agent/` 摊成 `Android/pi-root/`
- `Android/README.md`：首次与出包步骤

`interface.json` 在 `assets/`、agent 在仓库根，Gradle include 只能相对一个目录，所以先摊平。`pi-root/` 和 `agent-dist/` 是中间产物，已写进 `.gitignore`。

## 构建流程

```
git submodule update --init Android/MaaFwApp
python tools/prepare_android_pi.py
python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a
python Android/MaaFwApp/scripts/build_agent_bundle.py --out Android/agent-dist \
    --requirements requirements.txt \
    --exclude pillow --exclude win32-setctime --exclude colorama --exclude jeepney \
    --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
```

子模块 `local.properties` 写 `pi.profile=../profile.yaml`（不进 git）。包名 `com.aliothmoon.maafw.maanaruto`。

桌面端的 `child_exec` / `child_args` 不参与，设备上的解释器由配方里的 `bin/python3` 指定。
