### PR TITLE
ci(android): 构建 x86_64 安卓产物

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,9 +32,12 @@ permissions:
 
 jobs:
   debug:
-    name: Debug APK
+    name: Debug APK (${{ matrix.abi }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        abi: [arm64-v8a, x86_64]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -59,8 +62,9 @@ jobs:
           path: |
             Android/MaaFwApp/.maa-cache
             Android/MaaFwApp/.maafw
-          key: android-native-${{ runner.os }}-fw5.12.3-core3.13.15-arm64
+          key: android-native-${{ runner.os }}-fw5.12.3-core3.13.15-${{ matrix.abi }}
           restore-keys: |
+            android-native-${{ runner.os }}-fw5.12.3-core3.13.15-
             android-native-${{ runner.os }}-
 
       - name: Write local.properties
@@ -68,7 +72,7 @@ jobs:
           {
             echo "sdk.dir=${ANDROID_SDK_ROOT}"
             echo "pi.profile=../profile.yaml"
-            echo "build.debugAbi=arm64-v8a"
+            echo "build.debugAbi=${{ matrix.abi }}"
           } > Android/MaaFwApp/local.properties
 
       - name: Prepare PI tree
@@ -77,7 +81,7 @@ jobs:
       - name: Fetch MaaFramework native libs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python Android/MaaFwApp/scripts/setup_maa_framework.py --abi arm64-v8a --tag v5.12.3
+        run: python Android/MaaFwApp/scripts/setup_maa_framework.py --abi ${{ matrix.abi }} --tag v5.12.3
 
       - name: Pack agent runtime
         env:
@@ -96,7 +100,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: MaaAutoNaruto-android-arm64-${{ github.sha }}
+          name: MaaAutoNaruto-android-${{ matrix.abi }}-${{ github.sha }}
           path: Android/MaaFwApp/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
 

--- a/Android/profile.yaml
+++ b/Android/profile.yaml
@@ -23,7 +23,7 @@ exclude:
 #     --require pillow==11.0.0 --extra-index-url https://chaquo.com/pypi-13.1/
 agent:
   sourceDir: agent-dist
-  abi: [arm64-v8a]
+  abi: [arm64-v8a, x86_64]
   runtimes:
     - location: bundle
       executable: bin/python3


### PR DESCRIPTION
Add x86_64 to the Android agent runtime packaging and matrix debug CI. Release builds already package all native ABIs; this ensures the bundled Python runtime is present for x86_64 as well. Validated YAML parsing and git diff --check.