### PR TITLE
ci: add macOS and Android MirrorChyan uploads

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -15,14 +15,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [win, linux]
-        arch: [x86_64]
+        include:
+          - os: win
+            arch: x86_64
+            filename: "MaaAutoNaruto-win-x86_64-*.zip"
+          - os: linux
+            arch: x86_64
+            filename: "MaaAutoNaruto-linux-x86_64-*.zip"
+          - os: macos
+            arch: x86_64
+            filename: "MaaAutoNaruto-macos-x86_64-*.zip"
+          - os: macos
+            arch: aarch64
+            filename: "MaaAutoNaruto-macos-aarch64-*.zip"
+          - os: android
+            arch: ""
+            filename: "MaaAutoNaruto-android-*.apk"
     steps:
       - id: uploading
         uses: MirrorChyan/uploading-action@v1
         with:
           filetype: latest-release
-          filename: "MaaAutoNaruto-${{ matrix.os }}-${{ matrix.arch }}-*.zip"
+          filename: ${{ matrix.filename }}
           mirrorchyan_rid: MaaAutoNaruto
           tag: ${{ inputs.tag }}
 


### PR DESCRIPTION
## Summary
- upload macOS x86_64 and aarch64 release archives to MirrorChyan
- upload the universal Android APK as android-any
- keep the existing Windows and Linux x86_64 uploads unchanged

## Notes
- Verified asset globs against the latest GitHub release filenames.
- MirrorChyan may reject the new targets if the project supported platforms are not enabled in its dashboard.