### PR TITLE
refactor:将focus着色改为HTML4 font标签

### DIFF
--- a/assets/resource/base/pipeline/Activity.json
+++ b/assets/resource/base/pipeline/Activity.json
@@ -6,7 +6,9 @@
             "activity_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动任务</font>"
+        }
     },
     "activity_entry": {
         "recognition": "TemplateMatch",
@@ -195,7 +197,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">进行月度签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进行月度签到</font>"
+        }
     },
     "mouthly_signature_done": {
         "recognition": "OCR",
@@ -343,7 +347,9 @@
             "privilege_points",
             "click_privilege_store"
         ],
-        "focus": "<font color=\"DarkGray\">进入特权商店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGray\">进入特权商店</font>"
+        }
     },
     "privilege_points": {
         "recognition": "TemplateMatch",
@@ -403,7 +409,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DarkGoldenRod\">没有充值按钮</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">没有充值按钮</font>"
+        },
         "$doc": "遇到真投入什么字也没有"
     },
     "get_copper_in_privilege_points": {

--- a/assets/resource/base/pipeline/Activity.json
+++ b/assets/resource/base/pipeline/Activity.json
@@ -6,7 +6,7 @@
             "activity_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动任务</font>"
     },
     "activity_entry": {
         "recognition": "TemplateMatch",
@@ -195,7 +195,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]进行月度签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进行月度签到</font>"
     },
     "mouthly_signature_done": {
         "recognition": "OCR",
@@ -343,7 +343,7 @@
             "privilege_points",
             "click_privilege_store"
         ],
-        "focus": "[color:DarkGray]进入特权商店[/color]"
+        "focus": "<font color=\"DarkGray\">进入特权商店</font>"
     },
     "privilege_points": {
         "recognition": "TemplateMatch",
@@ -403,7 +403,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DarkGoldenRod]没有充值按钮[/color]",
+        "focus": "<font color=\"DarkGoldenRod\">没有充值按钮</font>",
         "$doc": "遇到真投入什么字也没有"
     },
     "get_copper_in_privilege_points": {

--- a/assets/resource/base/pipeline/Advanture.json
+++ b/assets/resource/base/pipeline/Advanture.json
@@ -7,7 +7,9 @@
             "[JumpBack]advanture_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本任务</font>"
+        }
     },
     "advanture_entry": {
         "recognition": "TemplateMatch",
@@ -20,7 +22,9 @@
         "template": "Advanture/advanture_entry.png",
         "action": "Click",
         "post_delay": 3000,
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        }
     },
     "advanture_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -36,7 +40,9 @@
             "advanture_check_no_next_roll",
             "[JumpBack]advanture_to_next_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        }
     },
     "advanture_check_no_next_roll": {
         "recognition": "TemplateMatch",
@@ -60,7 +66,9 @@
             "advanture_new_level_undone",
             "naruto_journey_new_level_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确定没有下一个章节</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确定没有下一个章节</font>"
+        }
     },
     "advanture_to_next_roll": {
         "recognition": "TemplateMatch",
@@ -79,7 +87,9 @@
             82
         ],
         "post_delay": 900,
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本下一个章节</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本下一个章节</font>"
+        }
     },
     "advanture_new_level_undone": {
         "recognition": "TemplateMatch",
@@ -98,7 +108,9 @@
             "level_not_enough",
             "advanture_new_level_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本新关卡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本新关卡</font>"
+        }
     },
     "level_not_enough": {
         "recognition": "TemplateMatch",
@@ -110,7 +122,9 @@
         ],
         "template": "Advanture/level_not_enough.png",
         "next": "back_main_screen_and_stop",
-        "focus": "等级不足"
+        "focus": {
+            "Node.Action.Starting": "等级不足"
+        }
     },
     "naruto_journey_new_level_undone": {
         "recognition": "TemplateMatch",
@@ -128,7 +142,9 @@
             "[JumpBack]get_red_envelope",
             "naruto_journey_new_level_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本鸣人征程新关卡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本鸣人征程新关卡</font>"
+        }
     },
     "advanture_go_fight": {
         "recognition": "TemplateMatch",
@@ -153,7 +169,9 @@
             "advanture_go_fight",
             "[JumpBack]advanture_skip_dialogue"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        }
     },
     "advanture_skip_dialogue": {
         "recognition": "TemplateMatch",
@@ -185,7 +203,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">高级任务无法自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">高级任务无法自动战斗</font>"
+        }
     },
     "advanture_anime": {
         "recognition": "Or",
@@ -236,7 +256,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 300,
-        "focus": "<font color=\"DeepSkyBlue\">剧情动画</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">剧情动画</font>"
+        }
     },
     "advanture_anime_skip": {
         "recognition": "OCR",
@@ -274,7 +296,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 300,
-        "focus": "<font color=\"DeepSkyBlue\">过场动画上黑框</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">过场动画上黑框</font>"
+        }
     },
     "advanture_in_fight": {
         "recognition": "OCR",
@@ -311,7 +335,9 @@
             "[JumpBack]advanture_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入战斗</font>"
+        }
     },
     "has_stop_button": {
         "recognition": "TemplateMatch",
@@ -362,7 +388,9 @@
             "[JumpBack]advanture_anime",
             "[JumpBack]advanture_skip_dialogue"
         ],
-        "focus": "检查自动战斗状态"
+        "focus": {
+            "Node.Action.Starting": "检查自动战斗状态"
+        }
     },
     "check_in_auto_fight": {
         "recognition": "OCR",
@@ -393,7 +421,9 @@
         "action": "Click",
         "post_delay": 0,
         "timeout": 30000,
-        "focus": "<font color=\"DeepSkyBlue\">开启自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开启自动战斗</font>"
+        }
     },
     "advanture_win": {
         "recognition": "TemplateMatch",
@@ -410,7 +440,9 @@
             "quit_advanture_battle_from_win",
             "advanture_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">胜利啦</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">胜利啦</font>"
+        }
     },
     "advanture_new_function_unlock": {
         "recognition": "OCR",
@@ -428,7 +460,9 @@
         "next": [
             "advanture"
         ],
-        "focus": "新功能解锁"
+        "focus": {
+            "Node.Action.Starting": "新功能解锁"
+        }
     },
     "quit_advanture_battle_from_win": {
         "recognition": "TemplateMatch",
@@ -451,7 +485,9 @@
             "advanture_in_level_roll",
             "advanture_rank_up"
         ],
-        "focus": "返回主页检查是否有新功能"
+        "focus": {
+            "Node.Action.Starting": "返回主页检查是否有新功能"
+        }
     },
     "advanture_lost": {
         "recognition": "OCR",
@@ -470,7 +506,9 @@
             "advanture_not_in_lost",
             "advanture_lost"
         ],
-        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        }
     },
     "advanture_skip_revive": {
         "recognition": "OCR",
@@ -503,7 +541,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        }
     },
     "advanture_daily_award_unlock": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Advanture.json
+++ b/assets/resource/base/pipeline/Advanture.json
@@ -7,7 +7,7 @@
             "[JumpBack]advanture_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入冒险副本任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本任务</font>"
     },
     "advanture_entry": {
         "recognition": "TemplateMatch",
@@ -20,7 +20,7 @@
         "template": "Advanture/advanture_entry.png",
         "action": "Click",
         "post_delay": 3000,
-        "focus": "[color:DeepSkyBlue]进入冒险副本入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
     },
     "advanture_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -36,7 +36,7 @@
             "advanture_check_no_next_roll",
             "[JumpBack]advanture_to_next_roll"
         ],
-        "focus": "[color:DeepSkyBlue]已经在冒险副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
     },
     "advanture_check_no_next_roll": {
         "recognition": "TemplateMatch",
@@ -60,7 +60,7 @@
             "advanture_new_level_undone",
             "naruto_journey_new_level_undone"
         ],
-        "focus": "[color:DeepSkyBlue]确定没有下一个章节[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确定没有下一个章节</font>"
     },
     "advanture_to_next_roll": {
         "recognition": "TemplateMatch",
@@ -79,7 +79,7 @@
             82
         ],
         "post_delay": 900,
-        "focus": "[color:DeepSkyBlue]进入冒险副本下一个章节[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本下一个章节</font>"
     },
     "advanture_new_level_undone": {
         "recognition": "TemplateMatch",
@@ -98,7 +98,7 @@
             "level_not_enough",
             "advanture_new_level_undone"
         ],
-        "focus": "[color:DeepSkyBlue]进入冒险副本新关卡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本新关卡</font>"
     },
     "level_not_enough": {
         "recognition": "TemplateMatch",
@@ -128,7 +128,7 @@
             "[JumpBack]get_red_envelope",
             "naruto_journey_new_level_undone"
         ],
-        "focus": "[color:DeepSkyBlue]进入冒险副本鸣人征程新关卡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本鸣人征程新关卡</font>"
     },
     "advanture_go_fight": {
         "recognition": "TemplateMatch",
@@ -153,7 +153,7 @@
             "advanture_go_fight",
             "[JumpBack]advanture_skip_dialogue"
         ],
-        "focus": "[color:DeepSkyBlue]开始战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
     },
     "advanture_skip_dialogue": {
         "recognition": "TemplateMatch",
@@ -185,7 +185,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]高级任务无法自动战斗[/color]"
+        "focus": "<font color=\"tomato\">高级任务无法自动战斗</font>"
     },
     "advanture_anime": {
         "recognition": "Or",
@@ -236,7 +236,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 300,
-        "focus": "[color:DeepSkyBlue]剧情动画[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">剧情动画</font>"
     },
     "advanture_anime_skip": {
         "recognition": "OCR",
@@ -274,7 +274,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 300,
-        "focus": "[color:DeepSkyBlue]过场动画上黑框[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">过场动画上黑框</font>"
     },
     "advanture_in_fight": {
         "recognition": "OCR",
@@ -311,7 +311,7 @@
             "[JumpBack]advanture_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入战斗</font>"
     },
     "has_stop_button": {
         "recognition": "TemplateMatch",
@@ -393,7 +393,7 @@
         "action": "Click",
         "post_delay": 0,
         "timeout": 30000,
-        "focus": "[color:DeepSkyBlue]开启自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开启自动战斗</font>"
     },
     "advanture_win": {
         "recognition": "TemplateMatch",
@@ -410,7 +410,7 @@
             "quit_advanture_battle_from_win",
             "advanture_win"
         ],
-        "focus": "[color:DeepSkyBlue]胜利啦[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">胜利啦</font>"
     },
     "advanture_new_function_unlock": {
         "recognition": "OCR",
@@ -470,7 +470,7 @@
             "advanture_not_in_lost",
             "advanture_lost"
         ],
-        "focus": "[color:tomato]胜败乃兵家常事[/color]"
+        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
     },
     "advanture_skip_revive": {
         "recognition": "OCR",
@@ -503,7 +503,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]胜败乃兵家常事[/color]"
+        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
     },
     "advanture_daily_award_unlock": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Asura_instance.json
+++ b/assets/resource/base/pipeline/Asura_instance.json
@@ -7,7 +7,9 @@
             "asura_instance_in_level_roll",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入修罗副本任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入修罗副本任务</font>"
+        }
     },
     "asura_instance_entry": {
         "recognition": "TemplateMatch",
@@ -25,7 +27,9 @@
             "asura_instance_in_level_roll",
             "[JumpBack]asura_instance_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        }
     },
     "asura_instance_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -42,7 +46,9 @@
         "next": [
             "asura_instance_to_asura_instance"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        }
     },
     "asura_instance_to_asura_instance": {
         "recognition": "TemplateMatch",
@@ -61,7 +67,9 @@
             "asura_instance_in_asura_instance",
             "[JumpBack]asura_instance_to_asura_instance"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">去在修罗副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">去在修罗副本</font>"
+        }
     },
     "asura_instance_in_asura_instance": {
         "recognition": "TemplateMatch",
@@ -78,6 +86,8 @@
             "advanture_check_no_next_roll",
             "[JumpBack]advanture_to_next_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已在修罗副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已在修罗副本</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Asura_instance.json
+++ b/assets/resource/base/pipeline/Asura_instance.json
@@ -7,7 +7,7 @@
             "asura_instance_in_level_roll",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入修罗副本任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入修罗副本任务</font>"
     },
     "asura_instance_entry": {
         "recognition": "TemplateMatch",
@@ -25,7 +25,7 @@
             "asura_instance_in_level_roll",
             "[JumpBack]asura_instance_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入冒险副本入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
     },
     "asura_instance_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -42,7 +42,7 @@
         "next": [
             "asura_instance_to_asura_instance"
         ],
-        "focus": "[color:DeepSkyBlue]已经在冒险副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
     },
     "asura_instance_to_asura_instance": {
         "recognition": "TemplateMatch",
@@ -61,7 +61,7 @@
             "asura_instance_in_asura_instance",
             "[JumpBack]asura_instance_to_asura_instance"
         ],
-        "focus": "[color:DeepSkyBlue]去在修罗副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">去在修罗副本</font>"
     },
     "asura_instance_in_asura_instance": {
         "recognition": "TemplateMatch",
@@ -78,6 +78,6 @@
             "advanture_check_no_next_roll",
             "[JumpBack]advanture_to_next_roll"
         ],
-        "focus": "[color:DeepSkyBlue]已在修罗副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已在修罗副本</font>"
     }
 }

--- a/assets/resource/base/pipeline/Black_market_merchant.json
+++ b/assets/resource/base/pipeline/Black_market_merchant.json
@@ -10,7 +10,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入秘境子任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
     },
     "open_black_market_merchant_by_guide": {
         "recognition": "Custom",
@@ -46,7 +46,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "black_market_merchant_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -192,7 +192,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]找不到黑市商人[/color]"
+        "focus": "<font color=\"tomato\">找不到黑市商人</font>"
     },
     "black_market_merchant_in_black_market_merchant": {
         "recognition": "TemplateMatch",
@@ -347,7 +347,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]道具不足[/color]"
+        "focus": "<font color=\"tomato\">道具不足</font>"
     },
     "black_market_merchant_add_gear_dust_quantity": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Black_market_merchant.json
+++ b/assets/resource/base/pipeline/Black_market_merchant.json
@@ -10,7 +10,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
+        }
     },
     "open_black_market_merchant_by_guide": {
         "recognition": "Custom",
@@ -46,7 +48,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "black_market_merchant_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -192,7 +196,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">找不到黑市商人</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">找不到黑市商人</font>"
+        }
     },
     "black_market_merchant_in_black_market_merchant": {
         "recognition": "TemplateMatch",
@@ -347,7 +353,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">道具不足</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">道具不足</font>"
+        }
     },
     "black_market_merchant_add_gear_dust_quantity": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Buy_energy.json
+++ b/assets/resource/base/pipeline/Buy_energy.json
@@ -6,7 +6,9 @@
             "buy_energy_in_main_screen",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入购买体力任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入购买体力任务</font>"
+        }
     },
     "buy_energy_in_main_screen": {
         "recognition": "TemplateMatch",
@@ -121,7 +123,9 @@
             "[JumpBack]pay_to_stronger_tip",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"pink\">检查购买体力次数</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">检查购买体力次数</font>"
+        }
     },
     "try_buy_energy": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Buy_energy.json
+++ b/assets/resource/base/pipeline/Buy_energy.json
@@ -6,7 +6,7 @@
             "buy_energy_in_main_screen",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入购买体力任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入购买体力任务</font>"
     },
     "buy_energy_in_main_screen": {
         "recognition": "TemplateMatch",
@@ -121,7 +121,7 @@
             "[JumpBack]pay_to_stronger_tip",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:pink]检查购买体力次数[/color]"
+        "focus": "<font color=\"pink\">检查购买体力次数</font>"
     },
     "try_buy_energy": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Champion_gift.json
+++ b/assets/resource/base/pipeline/Champion_gift.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冠军送礼任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冠军送礼任务</font>"
+        }
     },
     "go_into_champion_gift": {
         "recognition": {
@@ -33,7 +35,9 @@
             "champion_gift_to_event_center",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍者大赛</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍者大赛</font>"
+        }
     },
     "champion_gift_to_event_center": {
         "recognition": "TemplateMatch",
@@ -188,6 +192,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">冠军送礼完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">冠军送礼完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Champion_gift.json
+++ b/assets/resource/base/pipeline/Champion_gift.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入冠军送礼任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冠军送礼任务</font>"
     },
     "go_into_champion_gift": {
         "recognition": {
@@ -33,7 +33,7 @@
             "champion_gift_to_event_center",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍者大赛[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍者大赛</font>"
     },
     "champion_gift_to_event_center": {
         "recognition": "TemplateMatch",
@@ -188,6 +188,6 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]冠军送礼完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">冠军送礼完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Craft_gift.json
+++ b/assets/resource/base/pipeline/Craft_gift.json
@@ -7,7 +7,7 @@
             "craft_gift_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入合成赠礼任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼任务</font>"
     },
     "craft_gift_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +35,7 @@
             "[JumpBack]swipes_for_craft_gift",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入合成赠礼活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼活动</font>"
     },
     "swipes_for_craft_gift": {
         "max_hit": 5,
@@ -63,7 +63,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往合成赠礼[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往合成赠礼</font>"
     },
     "find_craft_gift": {
         "recognition": "OCR",
@@ -84,7 +84,7 @@
             "craft_gift_start",
             "[JumpBack]find_craft_gift"
         ],
-        "focus": "[color:DeepSkyBlue]找到合成赠礼[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到合成赠礼</font>"
     },
     "craft_gift_start": {
         "recognition": "TemplateMatch",
@@ -100,7 +100,7 @@
         "next": [
             "craft_gift_exchange"
         ],
-        "focus": "[color:DeepSkyBlue]进入合成赠礼游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼游戏</font>"
     },
     "craft_gift_exchange": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Craft_gift.json
+++ b/assets/resource/base/pipeline/Craft_gift.json
@@ -7,7 +7,9 @@
             "craft_gift_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入合成赠礼任务</font>"
+        }
     },
     "craft_gift_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +37,9 @@
             "[JumpBack]swipes_for_craft_gift",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入合成赠礼活动</font>"
+        }
     },
     "swipes_for_craft_gift": {
         "max_hit": 5,
@@ -63,7 +67,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往合成赠礼</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往合成赠礼</font>"
+        }
     },
     "find_craft_gift": {
         "recognition": "OCR",
@@ -84,7 +90,9 @@
             "craft_gift_start",
             "[JumpBack]find_craft_gift"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到合成赠礼</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到合成赠礼</font>"
+        }
     },
     "craft_gift_start": {
         "recognition": "TemplateMatch",
@@ -100,7 +108,9 @@
         "next": [
             "craft_gift_exchange"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入合成赠礼游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入合成赠礼游戏</font>"
+        }
     },
     "craft_gift_exchange": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Easy_helper.json
+++ b/assets/resource/base/pipeline/Easy_helper.json
@@ -8,7 +8,7 @@
             "easy_helper_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入轻松助手任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入轻松助手任务</font>"
     },
     "easy_helper_done": {
         "recognition": "TemplateMatch",
@@ -25,7 +25,7 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]轻松助手已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松助手已完成</font>"
     },
     "easy_helper_enter": {
         "recognition": "TemplateMatch",
@@ -46,7 +46,7 @@
             "easy_helper_one_key",
             "[JumpBack]easy_helper_daily"
         ],
-        "focus": "[color:DeepSkyBlue]进入轻松助手[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入轻松助手</font>"
     },
     "easy_helper_daily": {
         "recognition": "TemplateMatch",
@@ -60,7 +60,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]点击一键审批[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击一键审批</font>"
     },
     "easy_helper_one_key": {
         "recognition": "TemplateMatch",
@@ -83,7 +83,7 @@
             "easy_helper_no_gold_sweep",
             "[JumpBack]easy_helper_one_key"
         ],
-        "focus": "[color:DeepSkyBlue]打开轻松助手[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开轻松助手</font>"
     },
     "easy_helper_one_key_done": {
         "recognition": "OCR",
@@ -123,7 +123,7 @@
             "easy_helper_one_key_done",
             "confirm_easy_helper_one_key"
         ],
-        "focus": "[color:DeepSkyBlue]不进行金币扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
     },
     "confirm_easy_helper_one_key": {
         "recognition": "OCR",
@@ -150,7 +150,7 @@
             "confirm_easy_helper_one_key",
             "confirm_easy_helper_one_key_done"
         ],
-        "focus": "[color:DeepSkyBlue]一键审批[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">一键审批</font>"
     },
     "confirm_easy_helper_one_key_done": {
         "recognition": "TemplateMatch",
@@ -167,7 +167,7 @@
             "easy_helper_log_on_award_undone",
             "easy_helper_log_on_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]确认一键审批已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认一键审批已完成</font>"
     },
     "easy_helper_log_on_award_undone": {
         "recognition": "TemplateMatch",
@@ -187,7 +187,7 @@
             "easy_helper_check_in_log_on_award",
             "[JumpBack]easy_helper_log_on_award_undone"
         ],
-        "focus": "[color:DeepSkyBlue]轻松助手奖励未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松助手奖励未领取</font>"
     },
     "easy_helper_check_in_log_on_award": {
         "recognition": "TemplateMatch",
@@ -225,7 +225,7 @@
             "easy_helper_privilege_undone",
             "easy_helper_privilege_done"
         ],
-        "focus": "[color:DeepSkyBlue]轻松助手奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松助手奖励已领取</font>"
     },
     "get_easy_helper_without_log_on_award": {
         "recognition": "TemplateMatch",
@@ -258,7 +258,7 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]领取签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取签到奖励</font>"
     },
     "easy_helper_privilege_done": {
         "recognition": "TemplateMatch",
@@ -277,7 +277,7 @@
         "next": [
             "easy_helper_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]轻松特权已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松特权已完成</font>"
     },
     "easy_helper_privilege_undone": {
         "recognition": "TemplateMatch",
@@ -297,7 +297,7 @@
             "easy_helper_sweep",
             "easy_helper_privilege_undone"
         ],
-        "focus": "[color:DeepSkyBlue]轻松特权未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松特权未完成</font>"
     },
     "easy_helper_sweep": {
         "recognition": "TemplateMatch",
@@ -334,7 +334,7 @@
         "next": [
             "easy_helper_team_dash_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]检查能否进行扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检查能否进行扫荡</font>"
     },
     "get_easy_helper_sweep": {
         "recognition": "TemplateMatch",
@@ -358,7 +358,7 @@
             "secret_realm_old_settlement",
             "easy_season_plus_find_sweep_card_event"
         ],
-        "focus": "[color:DeepSkyBlue]点击扫荡按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击扫荡按钮</font>"
     },
     "easy_helper_can_not_sweep": {
         "recognition": "OCR",
@@ -417,7 +417,7 @@
             "check_no_easy_helper_sweep",
             "[JumpBack]get_easy_helper_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]返回扫荡界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">返回扫荡界面</font>"
     },
     "easy_helper_celebrate_sweep": {
         "recognition": "TemplateMatch",
@@ -433,7 +433,7 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]领取扫荡奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
     },
     "easy_helper_team_dash_sweep": {
         "pre_delay": 0,
@@ -461,7 +461,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]领取扫荡奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
     },
     "get_easy_helper_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -481,7 +481,7 @@
             "confirm_easy_helper_team_dash_sweep",
             "[JumpBack]easy_helper_back_to_team_dash_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]开始小队扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始小队扫荡</font>"
     },
     "confirm_easy_helper_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -500,7 +500,7 @@
             "check_easy_helper_back_to_team_dash_sweep",
             "[JumpBack]easy_helper_back_to_team_dash_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]继续扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
     },
     "check_easy_helper_back_to_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -519,7 +519,7 @@
         "next": [
             "easy_helper_team_dash_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]检测返回图标[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测返回图标</font>"
     },
     "easy_helper_back_to_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -535,6 +535,6 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]返回小队扫荡界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">返回小队扫荡界面</font>"
     }
 }

--- a/assets/resource/base/pipeline/Easy_helper.json
+++ b/assets/resource/base/pipeline/Easy_helper.json
@@ -8,7 +8,9 @@
             "easy_helper_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入轻松助手任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入轻松助手任务</font>"
+        }
     },
     "easy_helper_done": {
         "recognition": "TemplateMatch",
@@ -25,7 +27,9 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">轻松助手已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松助手已完成</font>"
+        }
     },
     "easy_helper_enter": {
         "recognition": "TemplateMatch",
@@ -46,7 +50,9 @@
             "easy_helper_one_key",
             "[JumpBack]easy_helper_daily"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入轻松助手</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入轻松助手</font>"
+        }
     },
     "easy_helper_daily": {
         "recognition": "TemplateMatch",
@@ -60,7 +66,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">点击一键审批</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击一键审批</font>"
+        }
     },
     "easy_helper_one_key": {
         "recognition": "TemplateMatch",
@@ -83,7 +91,9 @@
             "easy_helper_no_gold_sweep",
             "[JumpBack]easy_helper_one_key"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">打开轻松助手</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开轻松助手</font>"
+        }
     },
     "easy_helper_one_key_done": {
         "recognition": "OCR",
@@ -123,7 +133,9 @@
             "easy_helper_one_key_done",
             "confirm_easy_helper_one_key"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
+        }
     },
     "confirm_easy_helper_one_key": {
         "recognition": "OCR",
@@ -150,7 +162,9 @@
             "confirm_easy_helper_one_key",
             "confirm_easy_helper_one_key_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">一键审批</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">一键审批</font>"
+        }
     },
     "confirm_easy_helper_one_key_done": {
         "recognition": "TemplateMatch",
@@ -167,7 +181,9 @@
             "easy_helper_log_on_award_undone",
             "easy_helper_log_on_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认一键审批已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认一键审批已完成</font>"
+        }
     },
     "easy_helper_log_on_award_undone": {
         "recognition": "TemplateMatch",
@@ -187,7 +203,9 @@
             "easy_helper_check_in_log_on_award",
             "[JumpBack]easy_helper_log_on_award_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">轻松助手奖励未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松助手奖励未领取</font>"
+        }
     },
     "easy_helper_check_in_log_on_award": {
         "recognition": "TemplateMatch",
@@ -225,7 +243,9 @@
             "easy_helper_privilege_undone",
             "easy_helper_privilege_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">轻松助手奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松助手奖励已领取</font>"
+        }
     },
     "get_easy_helper_without_log_on_award": {
         "recognition": "TemplateMatch",
@@ -258,7 +278,9 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">领取签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取签到奖励</font>"
+        }
     },
     "easy_helper_privilege_done": {
         "recognition": "TemplateMatch",
@@ -277,7 +299,9 @@
         "next": [
             "easy_helper_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">轻松特权已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松特权已完成</font>"
+        }
     },
     "easy_helper_privilege_undone": {
         "recognition": "TemplateMatch",
@@ -297,7 +321,9 @@
             "easy_helper_sweep",
             "easy_helper_privilege_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">轻松特权未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松特权未完成</font>"
+        }
     },
     "easy_helper_sweep": {
         "recognition": "TemplateMatch",
@@ -334,7 +360,9 @@
         "next": [
             "easy_helper_team_dash_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检查能否进行扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检查能否进行扫荡</font>"
+        }
     },
     "get_easy_helper_sweep": {
         "recognition": "TemplateMatch",
@@ -358,7 +386,9 @@
             "secret_realm_old_settlement",
             "easy_season_plus_find_sweep_card_event"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击扫荡按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击扫荡按钮</font>"
+        }
     },
     "easy_helper_can_not_sweep": {
         "recognition": "OCR",
@@ -417,7 +447,9 @@
             "check_no_easy_helper_sweep",
             "[JumpBack]get_easy_helper_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">返回扫荡界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">返回扫荡界面</font>"
+        }
     },
     "easy_helper_celebrate_sweep": {
         "recognition": "TemplateMatch",
@@ -433,7 +465,9 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
+        }
     },
     "easy_helper_team_dash_sweep": {
         "pre_delay": 0,
@@ -461,7 +495,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取扫荡奖励</font>"
+        }
     },
     "get_easy_helper_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -481,7 +517,9 @@
             "confirm_easy_helper_team_dash_sweep",
             "[JumpBack]easy_helper_back_to_team_dash_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始小队扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始小队扫荡</font>"
+        }
     },
     "confirm_easy_helper_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -500,7 +538,9 @@
             "check_easy_helper_back_to_team_dash_sweep",
             "[JumpBack]easy_helper_back_to_team_dash_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
+        }
     },
     "check_easy_helper_back_to_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -519,7 +559,9 @@
         "next": [
             "easy_helper_team_dash_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测返回图标</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测返回图标</font>"
+        }
     },
     "easy_helper_back_to_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -535,6 +577,8 @@
         "action": "Click",
         "post_wait_freezes": 100,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">返回小队扫荡界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">返回小队扫荡界面</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Easy_season.json
+++ b/assets/resource/base/pipeline/Easy_season.json
@@ -7,7 +7,9 @@
             "easy_season_may_be_in_more",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入轻松季任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入轻松季任务</font>"
+        }
     },
     "easy_season_done": {
         "recognition": "TemplateMatch",
@@ -22,7 +24,9 @@
         "method": 10001,
         "threshold": 0.95,
         "action": "StopTask",
-        "focus": "<font color=\"DeepSkyBlue\">轻松季已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">轻松季已完成</font>"
+        }
     },
     "easy_season_enter": {
         "recognition": "TemplateMatch",
@@ -43,7 +47,9 @@
             "easy_season_in_easy_season",
             "easy_season_to_easy_helper"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
+        }
     },
     "easy_season_in_easy_season": {
         "recognition": "TemplateMatch",
@@ -95,7 +101,9 @@
             "easy_season_in_easy_helper",
             "easy_season_to_easy_helper"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击轻松季</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击轻松季</font>"
+        }
     },
     "easy_season_easy_helper_not_open": {
         "recognition": "TemplateMatch",
@@ -135,7 +143,9 @@
             "confirm_easy_season_one_key",
             "[JumpBack]easy_season_one_key"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">打开轻松季</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开轻松季</font>"
+        }
     },
     "easy_season_one_key_done": {
         "recognition": "OCR",
@@ -172,7 +182,9 @@
             "easy_season_one_key_done",
             "confirm_easy_season_one_key"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
+        }
     },
     "confirm_easy_season_one_key": {
         "recognition": "TemplateMatch",
@@ -231,7 +243,9 @@
             "easy_season_in_more",
             "easy_season_may_be_in_more"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
+        }
     },
     "easy_season_plus_to_easy_season": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Easy_season.json
+++ b/assets/resource/base/pipeline/Easy_season.json
@@ -7,7 +7,7 @@
             "easy_season_may_be_in_more",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入轻松季任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入轻松季任务</font>"
     },
     "easy_season_done": {
         "recognition": "TemplateMatch",
@@ -22,7 +22,7 @@
         "method": 10001,
         "threshold": 0.95,
         "action": "StopTask",
-        "focus": "[color:DeepSkyBlue]轻松季已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">轻松季已完成</font>"
     },
     "easy_season_enter": {
         "recognition": "TemplateMatch",
@@ -43,7 +43,7 @@
             "easy_season_in_easy_season",
             "easy_season_to_easy_helper"
         ],
-        "focus": "[color:DeepSkyBlue]进入轻松季[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
     },
     "easy_season_in_easy_season": {
         "recognition": "TemplateMatch",
@@ -95,7 +95,7 @@
             "easy_season_in_easy_helper",
             "easy_season_to_easy_helper"
         ],
-        "focus": "[color:DeepSkyBlue]点击轻松季[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击轻松季</font>"
     },
     "easy_season_easy_helper_not_open": {
         "recognition": "TemplateMatch",
@@ -135,7 +135,7 @@
             "confirm_easy_season_one_key",
             "[JumpBack]easy_season_one_key"
         ],
-        "focus": "[color:DeepSkyBlue]打开轻松季[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开轻松季</font>"
     },
     "easy_season_one_key_done": {
         "recognition": "OCR",
@@ -172,7 +172,7 @@
             "easy_season_one_key_done",
             "confirm_easy_season_one_key"
         ],
-        "focus": "[color:DeepSkyBlue]不进行金币扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不进行金币扫荡</font>"
     },
     "confirm_easy_season_one_key": {
         "recognition": "TemplateMatch",
@@ -231,7 +231,7 @@
             "easy_season_in_more",
             "easy_season_may_be_in_more"
         ],
-        "focus": "[color:DeepSkyBlue]进入轻松季[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入轻松季</font>"
     },
     "easy_season_plus_to_easy_season": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Elite_instance.json
+++ b/assets/resource/base/pipeline/Elite_instance.json
@@ -7,7 +7,7 @@
             "[JumpBack]elite_instance_to_level_roll",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入精英副本任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入精英副本任务</font>"
     },
     "elite_instance_entry": {
         "recognition": "TemplateMatch",
@@ -25,7 +25,7 @@
             "[JumpBack]elite_instance_to_level_roll",
             "[JumpBack]elite_instance_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入冒险副本入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
     },
     "elite_instance_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -40,7 +40,7 @@
         "next": [
             "elite_instance_to_elite_instance"
         ],
-        "focus": "[color:DeepSkyBlue]已经在冒险副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
     },
     "elite_instance_to_elite_instance": {
         "recognition": "TemplateMatch",
@@ -87,7 +87,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]全部关卡已经完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">全部关卡已经完成</font>"
     },
     "elite_instance_new_level_undone": {
         "recognition": "TemplateMatch",
@@ -102,7 +102,7 @@
         "next": [
             "elite_instance_go_fight"
         ],
-        "focus": "[color:DeepSkyBlue]进入精英副本新关卡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入精英副本新关卡</font>"
     },
     "elite_instance_go_fight": {
         "recognition": "TemplateMatch",
@@ -121,7 +121,7 @@
             "use_energy_not_enough_sign",
             "elite_instance_go_fight"
         ],
-        "focus": "[color:DeepSkyBlue]开始战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
     },
     "elite_instance_in_fight": {
         "recognition": "TemplateMatch",
@@ -141,7 +141,7 @@
             "elite_instance_not_in_fight",
             "[JumpBack]elite_instance_check_not_in_auto_fight"
         ],
-        "focus": "[color:DeepSkyBlue]战斗中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗中</font>"
     },
     "elite_instance_has_stop_button": {
         "recognition": "TemplateMatch",
@@ -207,7 +207,7 @@
             "elite_instance_not_in_fight",
             "[JumpBack]elite_instance_not_in_auto_fight"
         ],
-        "focus": "[color:DeepSkyBlue]打开自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
     },
     "elite_instance_not_in_fight": {
         "recognition": "TemplateMatch",
@@ -228,7 +228,7 @@
             "elite_instance_lock",
             "elite_instance_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]不在战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不在战斗</font>"
     },
     "elite_instance_not_in_auto_fight": {
         "recognition": "TemplateMatch",
@@ -242,7 +242,7 @@
         "next": [
             "elite_instance_auto_fight"
         ],
-        "focus": "[color:DeepSkyBlue]不在自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
     },
     "elite_instance_win": {
         "recognition": "TemplateMatch",
@@ -261,7 +261,7 @@
             "[JumpBack]elite_instance_win",
             "elite_instance_rank_up"
         ],
-        "focus": "[color:DeepSkyBlue]胜利啦[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">胜利啦</font>"
     },
     "elite_instance_lost": {
         "recognition": "OCR",
@@ -279,7 +279,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]胜败乃兵家常事[/color]"
+        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
     },
     "elite_instance_lock": {
         "recognition": "OCR",
@@ -298,7 +298,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]下一关未解锁[/color]"
+        "focus": "<font color=\"tomato\">下一关未解锁</font>"
     },
     "elite_instance_rank_up": {
         "recognition": "OCR",
@@ -320,7 +320,7 @@
             "elite_instance_to_elite_instance",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:tomato]升级了[/color]"
+        "focus": "<font color=\"tomato\">升级了</font>"
     },
     "elite_instance_to_level_roll": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Elite_instance.json
+++ b/assets/resource/base/pipeline/Elite_instance.json
@@ -7,7 +7,9 @@
             "[JumpBack]elite_instance_to_level_roll",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入精英副本任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入精英副本任务</font>"
+        }
     },
     "elite_instance_entry": {
         "recognition": "TemplateMatch",
@@ -25,7 +27,9 @@
             "[JumpBack]elite_instance_to_level_roll",
             "[JumpBack]elite_instance_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入冒险副本入口</font>"
+        }
     },
     "elite_instance_in_level_roll": {
         "recognition": "TemplateMatch",
@@ -40,7 +44,9 @@
         "next": [
             "elite_instance_to_elite_instance"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已经在冒险副本</font>"
+        }
     },
     "elite_instance_to_elite_instance": {
         "recognition": "TemplateMatch",
@@ -87,7 +93,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">全部关卡已经完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">全部关卡已经完成</font>"
+        }
     },
     "elite_instance_new_level_undone": {
         "recognition": "TemplateMatch",
@@ -102,7 +110,9 @@
         "next": [
             "elite_instance_go_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入精英副本新关卡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入精英副本新关卡</font>"
+        }
     },
     "elite_instance_go_fight": {
         "recognition": "TemplateMatch",
@@ -121,7 +131,9 @@
             "use_energy_not_enough_sign",
             "elite_instance_go_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        }
     },
     "elite_instance_in_fight": {
         "recognition": "TemplateMatch",
@@ -141,7 +153,9 @@
             "elite_instance_not_in_fight",
             "[JumpBack]elite_instance_check_not_in_auto_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗中</font>"
+        }
     },
     "elite_instance_has_stop_button": {
         "recognition": "TemplateMatch",
@@ -207,7 +221,9 @@
             "elite_instance_not_in_fight",
             "[JumpBack]elite_instance_not_in_auto_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
+        }
     },
     "elite_instance_not_in_fight": {
         "recognition": "TemplateMatch",
@@ -228,7 +244,9 @@
             "elite_instance_lock",
             "elite_instance_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不在战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不在战斗</font>"
+        }
     },
     "elite_instance_not_in_auto_fight": {
         "recognition": "TemplateMatch",
@@ -242,7 +260,9 @@
         "next": [
             "elite_instance_auto_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
+        }
     },
     "elite_instance_win": {
         "recognition": "TemplateMatch",
@@ -261,7 +281,9 @@
             "[JumpBack]elite_instance_win",
             "elite_instance_rank_up"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">胜利啦</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">胜利啦</font>"
+        }
     },
     "elite_instance_lost": {
         "recognition": "OCR",
@@ -279,7 +301,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">胜败乃兵家常事</font>"
+        }
     },
     "elite_instance_lock": {
         "recognition": "OCR",
@@ -298,7 +322,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">下一关未解锁</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">下一关未解锁</font>"
+        }
     },
     "elite_instance_rank_up": {
         "recognition": "OCR",
@@ -320,7 +346,9 @@
             "elite_instance_to_elite_instance",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"tomato\">升级了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">升级了</font>"
+        }
     },
     "elite_instance_to_level_roll": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Find_bonds.json
+++ b/assets/resource/base/pipeline/Find_bonds.json
@@ -5,7 +5,7 @@
             "find_bonds_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入羁绊追寻任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入羁绊追寻任务</font>"
     },
     "find_bonds_entry": {
         "recognition": "TemplateMatch",
@@ -31,7 +31,7 @@
             "[JumpBack]swipes_for_find_bonds",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "swipes_for_find_bonds": {
         "max_hit": 5,
@@ -50,7 +50,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往羁绊搜寻[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往羁绊搜寻</font>"
     },
     "find_find_bonds": {
         "recognition": "OCR",
@@ -69,7 +69,7 @@
             "find_bonds_card_flip_start",
             "[JumpBack]find_find_bonds"
         ],
-        "focus": "[color:DeepSkyBlue]找到羁绊追寻[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到羁绊追寻</font>"
     },
     "find_bonds_card_flip_start": {
         "recognition": "OCR",
@@ -86,7 +86,7 @@
             "find_bonds_without_enough_token",
             "find_bonds_card_flip_loop"
         ],
-        "focus": "[color:DeepSkyBlue]进入翻牌游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入翻牌游戏</font>"
     },
     "find_bonds_without_enough_token": {
         "recognition": {
@@ -99,7 +99,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]检测翻牌卷数量不足5则退出,足够则继续翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测翻牌卷数量不足5则退出,足够则继续翻牌</font>"
     },
     "find_bonds_card_flip_loop": {
         "recognition": {
@@ -115,7 +115,7 @@
             "find_bonds_without_enough_token",
             "[JumpBack]find_bonds_card_flip_loop"
         ],
-        "focus": "[color:DeepSkyBlue]自动翻牌中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">自动翻牌中</font>"
     },
     "find_bonds_card_flip_win": {
         "recognition": "TemplateMatch",
@@ -138,7 +138,7 @@
             "find_bonds_without_card_flip_win",
             "[JumpBack]find_bonds_card_flip_win"
         ],
-        "focus": "[color:DeepSkyBlue]翻牌胜利[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">翻牌胜利</font>"
     },
     "find_bonds_without_card_flip_win": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Find_bonds.json
+++ b/assets/resource/base/pipeline/Find_bonds.json
@@ -5,7 +5,9 @@
             "find_bonds_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入羁绊追寻任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入羁绊追寻任务</font>"
+        }
     },
     "find_bonds_entry": {
         "recognition": "TemplateMatch",
@@ -31,7 +33,9 @@
             "[JumpBack]swipes_for_find_bonds",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "swipes_for_find_bonds": {
         "max_hit": 5,
@@ -50,7 +54,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往羁绊搜寻</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往羁绊搜寻</font>"
+        }
     },
     "find_find_bonds": {
         "recognition": "OCR",
@@ -69,7 +75,9 @@
             "find_bonds_card_flip_start",
             "[JumpBack]find_find_bonds"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到羁绊追寻</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到羁绊追寻</font>"
+        }
     },
     "find_bonds_card_flip_start": {
         "recognition": "OCR",
@@ -86,7 +94,9 @@
             "find_bonds_without_enough_token",
             "find_bonds_card_flip_loop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入翻牌游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入翻牌游戏</font>"
+        }
     },
     "find_bonds_without_enough_token": {
         "recognition": {
@@ -99,7 +109,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测翻牌卷数量不足5则退出,足够则继续翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测翻牌卷数量不足5则退出,足够则继续翻牌</font>"
+        }
     },
     "find_bonds_card_flip_loop": {
         "recognition": {
@@ -115,7 +127,9 @@
             "find_bonds_without_enough_token",
             "[JumpBack]find_bonds_card_flip_loop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">自动翻牌中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">自动翻牌中</font>"
+        }
     },
     "find_bonds_card_flip_win": {
         "recognition": "TemplateMatch",
@@ -138,7 +152,9 @@
             "find_bonds_without_card_flip_win",
             "[JumpBack]find_bonds_card_flip_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">翻牌胜利</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">翻牌胜利</font>"
+        }
     },
     "find_bonds_without_card_flip_win": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Fine_gift_bell.json
+++ b/assets/resource/base/pipeline/Fine_gift_bell.json
@@ -8,7 +8,9 @@
             "fine_gift_bell_all",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入送好礼摇铃任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入送好礼摇铃任务</font>"
+        }
     },
     "fine_gift_bell_entry": {
         "recognition": "TemplateMatch",
@@ -36,7 +38,9 @@
             "[JumpBack]swipes_for_fine_gift_bell",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "find_fine_gift_bell": {
         "recognition": "OCR",
@@ -56,7 +60,9 @@
             "fine_gift_bell_all",
             "find_fine_gift_bell"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到送好礼摇铃</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到送好礼摇铃</font>"
+        }
     },
     "select_fine_gift_bell": {
         "recognition": "TemplateMatch",
@@ -74,7 +80,9 @@
             "fine_gift_get_voucher_done",
             "fine_gift_bell_all"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中送好礼摇铃</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中送好礼摇铃</font>"
+        }
     },
     "swipes_for_fine_gift_bell": {
         "max_hit": 5,
@@ -94,7 +102,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往送好礼摇铃</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往送好礼摇铃</font>"
+        }
     },
     "fine_gift_get_voucher": {
         "recognition": "OCR",
@@ -224,7 +234,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
+        }
     },
     "fine_gift_bell_all": {
         "recognition": "OCR",
@@ -238,6 +250,8 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Fine_gift_bell.json
+++ b/assets/resource/base/pipeline/Fine_gift_bell.json
@@ -8,7 +8,7 @@
             "fine_gift_bell_all",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入送好礼摇铃任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入送好礼摇铃任务</font>"
     },
     "fine_gift_bell_entry": {
         "recognition": "TemplateMatch",
@@ -36,7 +36,7 @@
             "[JumpBack]swipes_for_fine_gift_bell",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "find_fine_gift_bell": {
         "recognition": "OCR",
@@ -56,7 +56,7 @@
             "fine_gift_bell_all",
             "find_fine_gift_bell"
         ],
-        "focus": "[color:DeepSkyBlue]找到送好礼摇铃[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到送好礼摇铃</font>"
     },
     "select_fine_gift_bell": {
         "recognition": "TemplateMatch",
@@ -74,7 +74,7 @@
             "fine_gift_get_voucher_done",
             "fine_gift_bell_all"
         ],
-        "focus": "[color:DeepSkyBlue]选中送好礼摇铃[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中送好礼摇铃</font>"
     },
     "swipes_for_fine_gift_bell": {
         "max_hit": 5,
@@ -94,7 +94,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往送好礼摇铃[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往送好礼摇铃</font>"
     },
     "fine_gift_get_voucher": {
         "recognition": "OCR",
@@ -224,7 +224,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]礼卷不足[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
     },
     "fine_gift_bell_all": {
         "recognition": "OCR",
@@ -238,6 +238,6 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]礼卷不足[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">礼卷不足</font>"
     }
 }

--- a/assets/resource/base/pipeline/Flower_shop.json
+++ b/assets/resource/base/pipeline/Flower_shop.json
@@ -7,7 +7,9 @@
             "flower_shop_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入花店任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入花店任务</font>"
+        }
     },
     "flower_shop_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +37,9 @@
             "[JumpBack]swipes_for_flower_shop",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "find_flower_shop": {
         "recognition": "OCR",
@@ -54,7 +58,9 @@
             "select_flower_shop",
             "find_flower_shop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到花店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到花店</font>"
+        }
     },
     "select_flower_shop": {
         "recognition": "TemplateMatch",
@@ -71,7 +77,9 @@
             "flower_shop_undone",
             "flower_shop_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中花店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中花店</font>"
+        }
     },
     "swipes_for_flower_shop": {
         "max_hit": 5,
@@ -91,7 +99,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往花店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往花店</font>"
+        }
     },
     "flower_shop_undone": {
         "recognition": "TemplateMatch",
@@ -110,7 +120,9 @@
             "flower_shop_in_select_flower",
             "flower_shop_to_select_flower"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">可以种花</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">可以种花</font>"
+        }
     },
     "flower_shop_in_select_flower": {
         "recognition": "TemplateMatch",
@@ -126,7 +138,9 @@
         "next": [
             "flower_shop_in_choose_flower"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">在选花界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">在选花界面</font>"
+        }
     },
     "flower_shop_to_select_flower": {
         "recognition": "TemplateMatch",
@@ -145,7 +159,9 @@
             "flower_shop_in_select_flower",
             "[JumpBack]flower_shop_to_select_flower"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">去选花</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">去选花</font>"
+        }
     },
     "flower_shop_in_choose_flower": {
         "recognition": {
@@ -164,7 +180,9 @@
             "flower_shop_check_select_flower",
             "[JumpBack]flower_shop_in_choose_flower"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">寻找可以种的花</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找可以种的花</font>"
+        }
     },
     "flower_shop_check_select_flower": {
         "recognition": "TemplateMatch",
@@ -200,7 +218,9 @@
             "flower_shop_done",
             "[JumpBack]flower_shop_confirm_choose_flower"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确定种花</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确定种花</font>"
+        }
     },
     "flower_shop_not_select_flower": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Flower_shop.json
+++ b/assets/resource/base/pipeline/Flower_shop.json
@@ -7,7 +7,7 @@
             "flower_shop_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入花店任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入花店任务</font>"
     },
     "flower_shop_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +35,7 @@
             "[JumpBack]swipes_for_flower_shop",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "find_flower_shop": {
         "recognition": "OCR",
@@ -54,7 +54,7 @@
             "select_flower_shop",
             "find_flower_shop"
         ],
-        "focus": "[color:DeepSkyBlue]找到花店[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到花店</font>"
     },
     "select_flower_shop": {
         "recognition": "TemplateMatch",
@@ -71,7 +71,7 @@
             "flower_shop_undone",
             "flower_shop_done"
         ],
-        "focus": "[color:DeepSkyBlue]选中花店[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中花店</font>"
     },
     "swipes_for_flower_shop": {
         "max_hit": 5,
@@ -91,7 +91,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往花店[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往花店</font>"
     },
     "flower_shop_undone": {
         "recognition": "TemplateMatch",
@@ -110,7 +110,7 @@
             "flower_shop_in_select_flower",
             "flower_shop_to_select_flower"
         ],
-        "focus": "[color:DeepSkyBlue]可以种花[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">可以种花</font>"
     },
     "flower_shop_in_select_flower": {
         "recognition": "TemplateMatch",
@@ -126,7 +126,7 @@
         "next": [
             "flower_shop_in_choose_flower"
         ],
-        "focus": "[color:DeepSkyBlue]在选花界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">在选花界面</font>"
     },
     "flower_shop_to_select_flower": {
         "recognition": "TemplateMatch",
@@ -145,7 +145,7 @@
             "flower_shop_in_select_flower",
             "[JumpBack]flower_shop_to_select_flower"
         ],
-        "focus": "[color:DeepSkyBlue]去选花[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">去选花</font>"
     },
     "flower_shop_in_choose_flower": {
         "recognition": {
@@ -164,7 +164,7 @@
             "flower_shop_check_select_flower",
             "[JumpBack]flower_shop_in_choose_flower"
         ],
-        "focus": "[color:DeepSkyBlue]寻找可以种的花[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找可以种的花</font>"
     },
     "flower_shop_check_select_flower": {
         "recognition": "TemplateMatch",
@@ -200,7 +200,7 @@
             "flower_shop_done",
             "[JumpBack]flower_shop_confirm_choose_flower"
         ],
-        "focus": "[color:DeepSkyBlue]确定种花[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确定种花</font>"
     },
     "flower_shop_not_select_flower": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/Get_chopper.json
+++ b/assets/resource/base/pipeline/Get_chopper.json
@@ -7,7 +7,9 @@
             "[JumpBack]award_center_enter",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入铜币招财任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入铜币招财任务</font>"
+        }
     },
     "get_copper_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +28,9 @@
             "get_copper_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "get_copper_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -44,7 +48,9 @@
             "get_copper_in_center_enter",
             "get_copper_not_in_center_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        }
     },
     "get_copper_ac_entry": {
         "recognition": "TemplateMatch",
@@ -67,7 +73,9 @@
             "get_copper_not_in_center_enter",
             "get_copper_ac_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        }
     },
     "get_copper_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -128,7 +136,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">铜币招财已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">铜币招财已完成</font>"
+        }
     },
     "start_copper": {
         "recognition": "OCR",
@@ -144,7 +154,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 500,
-        "focus": "<font color=\"DeepSkyBlue\">进行招财</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进行招财</font>"
+        }
     },
     "check_free_copper_done": {
         "recognition": "OCR",
@@ -160,7 +172,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">免费铜币招财完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">免费铜币招财完成</font>"
+        }
     },
     "get_copper_with_secondary_password": {
         "pre_delay": 0,
@@ -171,7 +185,9 @@
             "free_copper_close_secondary_password",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"pink\">进入二级密码功能</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">进入二级密码功能</font>"
+        }
     },
     "free_copper_close_secondary_password": {
         "max_hit": 1,

--- a/assets/resource/base/pipeline/Get_chopper.json
+++ b/assets/resource/base/pipeline/Get_chopper.json
@@ -7,7 +7,7 @@
             "[JumpBack]award_center_enter",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入铜币招财任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入铜币招财任务</font>"
     },
     "get_copper_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +26,7 @@
             "get_copper_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "get_copper_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -44,7 +44,7 @@
             "get_copper_in_center_enter",
             "get_copper_not_in_center_enter"
         ],
-        "focus": "[color:DeepSkyBlue]奖励中心有奖励没领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
     },
     "get_copper_ac_entry": {
         "recognition": "TemplateMatch",
@@ -67,7 +67,7 @@
             "get_copper_not_in_center_enter",
             "get_copper_ac_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
     },
     "get_copper_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -128,7 +128,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]铜币招财已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">铜币招财已完成</font>"
     },
     "start_copper": {
         "recognition": "OCR",
@@ -144,7 +144,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 500,
-        "focus": "[color:DeepSkyBlue]进行招财[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进行招财</font>"
     },
     "check_free_copper_done": {
         "recognition": "OCR",
@@ -160,7 +160,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]免费铜币招财完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">免费铜币招财完成</font>"
     },
     "get_copper_with_secondary_password": {
         "pre_delay": 0,
@@ -171,7 +171,7 @@
             "free_copper_close_secondary_password",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:pink]进入二级密码功能[/color]"
+        "focus": "<font color=\"pink\">进入二级密码功能</font>"
     },
     "free_copper_close_secondary_password": {
         "max_hit": 1,

--- a/assets/resource/base/pipeline/Give_energy.json
+++ b/assets/resource/base/pipeline/Give_energy.json
@@ -8,7 +8,9 @@
             "give_energy_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入送体力任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入送体力任务</font>"
+        }
     },
     "energy_entry": {
         "recognition": "TemplateMatch",
@@ -31,7 +33,9 @@
             "sent_energy",
             "energy_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入送体力界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入送体力界面</font>"
+        }
     },
     "give_energy_account_friend": {
         "recognition": "OCR",
@@ -57,7 +61,9 @@
             "give_energy_in_account_friend",
             "give_energy_account_friend"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
+        }
     },
     "give_energy_in_account_friend": {
         "recognition": "TemplateMatch",
@@ -76,7 +82,9 @@
             "sent_energy",
             "energy_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
+        }
     },
     "give_energy_done": {
         "recognition": "TemplateMatch",
@@ -92,7 +100,9 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">送体力已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">送体力已完成</font>"
+        }
     },
     "sent_energy": {
         "recognition": "OCR",
@@ -109,7 +119,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "next": "get_energy",
-        "focus": "<font color=\"DeepSkyBlue\">送体力</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">送体力</font>"
+        }
     },
     "get_energy": {
         "recognition": "OCR",
@@ -129,7 +141,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取好友送的体力</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取好友送的体力</font>"
+        },
         "$doc": "一键领取体力后不需要点确定"
     }
 }

--- a/assets/resource/base/pipeline/Give_energy.json
+++ b/assets/resource/base/pipeline/Give_energy.json
@@ -8,7 +8,7 @@
             "give_energy_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入送体力任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入送体力任务</font>"
     },
     "energy_entry": {
         "recognition": "TemplateMatch",
@@ -31,7 +31,7 @@
             "sent_energy",
             "energy_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入送体力界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入送体力界面</font>"
     },
     "give_energy_account_friend": {
         "recognition": "OCR",
@@ -57,7 +57,7 @@
             "give_energy_in_account_friend",
             "give_energy_account_friend"
         ],
-        "focus": "[color:DeepSkyBlue]选择账号好友[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
     },
     "give_energy_in_account_friend": {
         "recognition": "TemplateMatch",
@@ -76,7 +76,7 @@
             "sent_energy",
             "energy_entry"
         ],
-        "focus": "[color:DeepSkyBlue]选择账号好友[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择账号好友</font>"
     },
     "give_energy_done": {
         "recognition": "TemplateMatch",
@@ -92,7 +92,7 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]送体力已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">送体力已完成</font>"
     },
     "sent_energy": {
         "recognition": "OCR",
@@ -109,7 +109,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "next": "get_energy",
-        "focus": "[color:DeepSkyBlue]送体力[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">送体力</font>"
     },
     "get_energy": {
         "recognition": "OCR",
@@ -129,7 +129,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]领取好友送的体力[/color]",
+        "focus": "<font color=\"DeepSkyBlue\">领取好友送的体力</font>",
         "$doc": "一键领取体力后不需要点确定"
     }
 }

--- a/assets/resource/base/pipeline/Group.json
+++ b/assets/resource/base/pipeline/Group.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入组织任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入组织任务</font>"
+        }
     },
     "goto_group_by_guide": {
         "recognition": "Custom",
@@ -26,7 +28,9 @@
             "no_group",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        }
     },
     "no_group": {
         "recognition": "TemplateMatch",
@@ -42,7 +46,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">没有加入组织</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">没有加入组织</font>"
+        }
     },
     "group_gameplay_undone": {
         "recognition": "TemplateMatch",
@@ -62,7 +68,9 @@
             "check_selected_group_gameplay",
             "group_gameplay_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织玩法未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织玩法未完成</font>"
+        }
     },
     "group_gameplay_done": {
         "recognition": "TemplateMatch",
@@ -77,7 +85,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">组织玩法已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织玩法已完成</font>"
+        }
     },
     "check_selected_group_gameplay": {
         "recognition": "TemplateMatch",
@@ -97,7 +107,9 @@
             "goto_group_pray",
             "check_selected_group_gameplay"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        }
     },
     "group_close_group_notice": {
         "recognition": "TemplateMatch",
@@ -147,7 +159,9 @@
             "above_kage_group_pray",
             "copper_group_pray"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入组织签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入组织签到</font>"
+        }
     },
     "above_kage_group_pray": {
         "recognition": "TemplateMatch",
@@ -166,7 +180,9 @@
             "confirm_copper_group_pray",
             "above_kage_group_pray"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">超影签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">超影签到</font>"
+        }
     },
     "copper_group_pray": {
         "recognition": "TemplateMatch",
@@ -185,7 +201,9 @@
             "confirm_copper_group_pray",
             "copper_group_pray"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">铜币签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">铜币签到</font>"
+        }
     },
     "confirm_copper_group_pray": {
         "recognition": "TemplateMatch",
@@ -231,7 +249,9 @@
             "first_group_award_done",
             "[JumpBack]first_group_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
+        }
     },
     "first_group_award_done": {
         "recognition": "TemplateMatch",
@@ -262,7 +282,9 @@
         "threshold": 0.92,
         "action": "Click",
         "post_wait_freezes": 700,
-        "focus": "<font color=\"DeepSkyBlue\">领取15人签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取15人签到奖励</font>"
+        }
     },
     "second_group_award_done": {
         "recognition": "TemplateMatch",
@@ -284,7 +306,9 @@
             "[JumpBack]third_group_award",
             "third_group_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">20人签到奖励已领取</font>"
+        }
     },
     "second_group_award": {
         "max_hit": 3,
@@ -307,7 +331,9 @@
             "second_group_award_box_done",
             "second_group_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取20人签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取20人签到奖励</font>"
+        }
     },
     "second_group_award_done_sign": {
         "recognition": "OCR",
@@ -342,7 +368,9 @@
         ],
         "post_wait_freezes": 800,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励金币已到账</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">20人签到奖励金币已到账</font>"
+        }
     },
     "second_group_award_box": {
         "recognition": "TemplateMatch",
@@ -362,7 +390,9 @@
             "close_second_group_award_box",
             "second_group_award_box"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励开箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">20人签到奖励开箱</font>"
+        }
     },
     "close_second_group_award_box": {
         "recognition": "TemplateMatch",
@@ -387,7 +417,9 @@
             "[JumpBack]third_group_award",
             "third_group_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭20人签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭20人签到奖励</font>"
+        }
     },
     "third_group_award_done": {
         "recognition": "TemplateMatch",
@@ -404,7 +436,9 @@
         "next": [
             "group_pray_to_pursuit_dawn_organization"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">25人签到奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">25人签到奖励已领取</font>"
+        }
     },
     "third_group_award": {
         "max_hit": 3,
@@ -424,7 +458,9 @@
         "next": [
             "close_third_group_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取25人签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取25人签到奖励</font>"
+        }
     },
     "close_third_group_award": {
         "recognition": "TemplateMatch",
@@ -439,7 +475,9 @@
         "action": "Click",
         "post_wait_freezes": 600,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">关闭25人签到奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭25人签到奖励</font>"
+        }
     },
     "group_pray_to_pursuit_dawn_organization": {
         "recognition": "OCR",
@@ -458,7 +496,9 @@
             "pursuit_dawn_organization_award",
             "[JumpBack]group_pray_to_pursuit_dawn_organization"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往追击晓组织</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往追击晓组织</font>"
+        }
     },
     "pursuit_dawn_organization_done": {
         "recognition": "TemplateMatch",
@@ -473,7 +513,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">追击晓组织已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">追击晓组织已完成</font>"
+        }
     },
     "pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -497,7 +539,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">追击晓组织奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">追击晓组织奖励已领取</font>"
+        }
     },
     "pursuit_dawn_organization_award_undone": {
         "recognition": "TemplateMatch",
@@ -517,7 +561,9 @@
             "[JumpBack]get_pursuit_dawn_organization_award",
             "pursuit_dawn_organization_award_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">追击晓组织奖励未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">追击晓组织奖励未领取</font>"
+        }
     },
     "one_key_get_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -533,7 +579,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">一键领取追击晓组织奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">一键领取追击晓组织奖励</font>"
+        }
     },
     "get_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -546,7 +594,9 @@
         "template": "Group/dawn_organization_award_waiting.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
+        }
     },
     "check_no_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -561,7 +611,9 @@
         "next": [
             "swipe_for_pursuit_dawn_organization_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测当前没有追击晓组织奖励可领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测当前没有追击晓组织奖励可领取</font>"
+        }
     },
     "swipe_for_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -591,7 +643,9 @@
             "check_no_pursuit_dawn_organization_award_1",
             "[JumpBack]get_pursuit_dawn_organization_award_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">下滑寻找追击晓组织奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">下滑寻找追击晓组织奖励</font>"
+        }
     },
     "get_pursuit_dawn_organization_award_1": {
         "recognition": "TemplateMatch",
@@ -604,7 +658,9 @@
         "template": "Group/dawn_organization_award_waiting.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
+        }
     },
     "check_no_pursuit_dawn_organization_award_1": {
         "recognition": "TemplateMatch",
@@ -636,7 +692,9 @@
             "yesterday_award_done",
             "[JumpBack]get_yesterday_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
+        }
     },
     "yesterday_award_done": {
         "recognition": "TemplateMatch",
@@ -652,7 +710,9 @@
         "next": [
             "close_yesterday_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">昨日奖励已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">昨日奖励已完成</font>"
+        }
     },
     "get_yesterday_award": {
         "recognition": "TemplateMatch",
@@ -665,7 +725,9 @@
         "template": "Group/get_yesterday_award.png",
         "action": "Click",
         "post_wait_freezes": 100,
-        "focus": "<font color=\"DeepSkyBlue\">领取昨日奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取昨日奖励</font>"
+        }
     },
     "close_yesterday_award": {
         "recognition": "TemplateMatch",
@@ -678,7 +740,9 @@
         "template": "Group/yesterday_award_done.png",
         "action": "Click",
         "post_wait_freezes": 500,
-        "focus": "<font color=\"DeepSkyBlue\">关闭昨日奖励界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭昨日奖励界面</font>"
+        }
     },
     "group_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -697,7 +761,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "group_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -725,6 +791,8 @@
             "no_group",
             "group_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织祈福未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织祈福未完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Group.json
+++ b/assets/resource/base/pipeline/Group.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入组织任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入组织任务</font>"
     },
     "goto_group_by_guide": {
         "recognition": "Custom",
@@ -26,7 +26,7 @@
             "no_group",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "[color:DeepSkyBlue]组织主界面入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
     },
     "no_group": {
         "recognition": "TemplateMatch",
@@ -42,7 +42,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]没有加入组织[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">没有加入组织</font>"
     },
     "group_gameplay_undone": {
         "recognition": "TemplateMatch",
@@ -62,7 +62,7 @@
             "check_selected_group_gameplay",
             "group_gameplay_undone"
         ],
-        "focus": "[color:DeepSkyBlue]组织玩法未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织玩法未完成</font>"
     },
     "group_gameplay_done": {
         "recognition": "TemplateMatch",
@@ -77,7 +77,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]组织玩法已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织玩法已完成</font>"
     },
     "check_selected_group_gameplay": {
         "recognition": "TemplateMatch",
@@ -97,7 +97,7 @@
             "goto_group_pray",
             "check_selected_group_gameplay"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中组织玩法按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
     },
     "group_close_group_notice": {
         "recognition": "TemplateMatch",
@@ -147,7 +147,7 @@
             "above_kage_group_pray",
             "copper_group_pray"
         ],
-        "focus": "[color:DeepSkyBlue]进入组织签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入组织签到</font>"
     },
     "above_kage_group_pray": {
         "recognition": "TemplateMatch",
@@ -166,7 +166,7 @@
             "confirm_copper_group_pray",
             "above_kage_group_pray"
         ],
-        "focus": "[color:DeepSkyBlue]超影签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">超影签到</font>"
     },
     "copper_group_pray": {
         "recognition": "TemplateMatch",
@@ -185,7 +185,7 @@
             "confirm_copper_group_pray",
             "copper_group_pray"
         ],
-        "focus": "[color:DeepSkyBlue]铜币签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">铜币签到</font>"
     },
     "confirm_copper_group_pray": {
         "recognition": "TemplateMatch",
@@ -231,7 +231,7 @@
             "first_group_award_done",
             "[JumpBack]first_group_award"
         ],
-        "focus": "[color:DeepSkyBlue]检测昨日奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
     },
     "first_group_award_done": {
         "recognition": "TemplateMatch",
@@ -262,7 +262,7 @@
         "threshold": 0.92,
         "action": "Click",
         "post_wait_freezes": 700,
-        "focus": "[color:DeepSkyBlue]领取15人签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取15人签到奖励</font>"
     },
     "second_group_award_done": {
         "recognition": "TemplateMatch",
@@ -284,7 +284,7 @@
             "[JumpBack]third_group_award",
             "third_group_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]20人签到奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励已领取</font>"
     },
     "second_group_award": {
         "max_hit": 3,
@@ -307,7 +307,7 @@
             "second_group_award_box_done",
             "second_group_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取20人签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取20人签到奖励</font>"
     },
     "second_group_award_done_sign": {
         "recognition": "OCR",
@@ -342,7 +342,7 @@
         ],
         "post_wait_freezes": 800,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]20人签到奖励金币已到账[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励金币已到账</font>"
     },
     "second_group_award_box": {
         "recognition": "TemplateMatch",
@@ -362,7 +362,7 @@
             "close_second_group_award_box",
             "second_group_award_box"
         ],
-        "focus": "[color:DeepSkyBlue]20人签到奖励开箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">20人签到奖励开箱</font>"
     },
     "close_second_group_award_box": {
         "recognition": "TemplateMatch",
@@ -387,7 +387,7 @@
             "[JumpBack]third_group_award",
             "third_group_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]关闭20人签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭20人签到奖励</font>"
     },
     "third_group_award_done": {
         "recognition": "TemplateMatch",
@@ -404,7 +404,7 @@
         "next": [
             "group_pray_to_pursuit_dawn_organization"
         ],
-        "focus": "[color:DeepSkyBlue]25人签到奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">25人签到奖励已领取</font>"
     },
     "third_group_award": {
         "max_hit": 3,
@@ -424,7 +424,7 @@
         "next": [
             "close_third_group_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取25人签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取25人签到奖励</font>"
     },
     "close_third_group_award": {
         "recognition": "TemplateMatch",
@@ -439,7 +439,7 @@
         "action": "Click",
         "post_wait_freezes": 600,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]关闭25人签到奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭25人签到奖励</font>"
     },
     "group_pray_to_pursuit_dawn_organization": {
         "recognition": "OCR",
@@ -458,7 +458,7 @@
             "pursuit_dawn_organization_award",
             "[JumpBack]group_pray_to_pursuit_dawn_organization"
         ],
-        "focus": "[color:DeepSkyBlue]前往追击晓组织[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往追击晓组织</font>"
     },
     "pursuit_dawn_organization_done": {
         "recognition": "TemplateMatch",
@@ -473,7 +473,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]追击晓组织已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">追击晓组织已完成</font>"
     },
     "pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -497,7 +497,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]追击晓组织奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">追击晓组织奖励已领取</font>"
     },
     "pursuit_dawn_organization_award_undone": {
         "recognition": "TemplateMatch",
@@ -517,7 +517,7 @@
             "[JumpBack]get_pursuit_dawn_organization_award",
             "pursuit_dawn_organization_award_undone"
         ],
-        "focus": "[color:DeepSkyBlue]追击晓组织奖励未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">追击晓组织奖励未领取</font>"
     },
     "one_key_get_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -533,7 +533,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]一键领取追击晓组织奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">一键领取追击晓组织奖励</font>"
     },
     "get_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -546,7 +546,7 @@
         "template": "Group/dawn_organization_award_waiting.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "[color:DeepSkyBlue]领取追击晓组织奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
     },
     "check_no_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -561,7 +561,7 @@
         "next": [
             "swipe_for_pursuit_dawn_organization_award"
         ],
-        "focus": "[color:DeepSkyBlue]检测当前没有追击晓组织奖励可领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测当前没有追击晓组织奖励可领取</font>"
     },
     "swipe_for_pursuit_dawn_organization_award": {
         "recognition": "TemplateMatch",
@@ -591,7 +591,7 @@
             "check_no_pursuit_dawn_organization_award_1",
             "[JumpBack]get_pursuit_dawn_organization_award_1"
         ],
-        "focus": "[color:DeepSkyBlue]下滑寻找追击晓组织奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">下滑寻找追击晓组织奖励</font>"
     },
     "get_pursuit_dawn_organization_award_1": {
         "recognition": "TemplateMatch",
@@ -604,7 +604,7 @@
         "template": "Group/dawn_organization_award_waiting.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "[color:DeepSkyBlue]领取追击晓组织奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取追击晓组织奖励</font>"
     },
     "check_no_pursuit_dawn_organization_award_1": {
         "recognition": "TemplateMatch",
@@ -636,7 +636,7 @@
             "yesterday_award_done",
             "[JumpBack]get_yesterday_award"
         ],
-        "focus": "[color:DeepSkyBlue]检测昨日奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测昨日奖励</font>"
     },
     "yesterday_award_done": {
         "recognition": "TemplateMatch",
@@ -652,7 +652,7 @@
         "next": [
             "close_yesterday_award"
         ],
-        "focus": "[color:DeepSkyBlue]昨日奖励已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">昨日奖励已完成</font>"
     },
     "get_yesterday_award": {
         "recognition": "TemplateMatch",
@@ -665,7 +665,7 @@
         "template": "Group/get_yesterday_award.png",
         "action": "Click",
         "post_wait_freezes": 100,
-        "focus": "[color:DeepSkyBlue]领取昨日奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取昨日奖励</font>"
     },
     "close_yesterday_award": {
         "recognition": "TemplateMatch",
@@ -678,7 +678,7 @@
         "template": "Group/yesterday_award_done.png",
         "action": "Click",
         "post_wait_freezes": 500,
-        "focus": "[color:DeepSkyBlue]关闭昨日奖励界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭昨日奖励界面</font>"
     },
     "group_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -697,7 +697,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "group_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -725,6 +725,6 @@
             "no_group",
             "group_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]组织祈福未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织祈福未完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Headhunt.json
+++ b/assets/resource/base/pipeline/Headhunt.json
@@ -6,7 +6,9 @@
             "headhunt_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入招募任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入招募任务</font>"
+        }
     },
     "headhunt_entry": {
         "recognition": "TemplateMatch",
@@ -63,7 +65,9 @@
             "headhunt_recruit_enter",
             "[JumpBack]swipe_for_headhunt_recruit_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">没有免费高级招募</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">没有免费高级招募</font>"
+        },
         "$doc": "因为高招有动画,所以这里不设post_wait_freezes"
     },
     "free_headhunt_waiting": {
@@ -86,7 +90,9 @@
             "free_headhunt_waiting",
             "[JumpBack]headhunt_whole_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">有免费高级招募</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">有免费高级招募</font>"
+        }
     },
     "headhunt_whole_ninja": {
         "recognition": "TemplateMatch",
@@ -101,7 +107,9 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">整卡!</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">整卡!</font>"
+        }
     },
     "free_headhunt_fake": {
         "recognition": "OCR",
@@ -118,7 +126,9 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "<font color=\"DarkGoldenRod\">什么,情报是假的</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">什么,情报是假的</font>"
+        }
     },
     "confirm_free_headhunt": {
         "max_hit": 5,
@@ -138,7 +148,9 @@
             "without_confirm_free_headhunt",
             "confirm_free_headhunt"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认免费高级招募</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认免费高级招募</font>"
+        }
     },
     "without_confirm_free_headhunt": {
         "recognition": "TemplateMatch",
@@ -153,7 +165,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [],
-        "focus": "<font color=\"DeepSkyBlue\">完成免费高级招募</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">完成免费高级招募</font>"
+        }
     },
     "swipe_for_headhunt_recruit_enter": {
         "max_hit": 3,
@@ -206,7 +220,9 @@
             "headhunt_recruit_no_free",
             "[JumpBack]headhunt_recruit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入普通招募</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入普通招募</font>"
+        }
     },
     "headhunt_recruit_no_free": {
         "recognition": "TemplateMatch",
@@ -227,7 +243,9 @@
             "top_secret_treasure_box_undone",
             "top_secret_treasure_box_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">免费普通招募已使用</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">免费普通招募已使用</font>"
+        }
     },
     "headhunt_recruit": {
         "recognition": "TemplateMatch",
@@ -251,7 +269,9 @@
             "headhunt_recruit",
             "[JumpBack]headhunt_whole_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进行免费普通招募</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进行免费普通招募</font>"
+        }
     },
     "confirm_headhunt_recruit": {
         "recognition": "OCR",
@@ -292,7 +312,9 @@
             "top_secret_treasure_box_log",
             "top_secret_treasure_box_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">绝密宝匣未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">绝密宝匣未完成</font>"
+        }
     },
     "top_secret_treasure_box_done": {
         "recognition": "TemplateMatch",
@@ -310,7 +332,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">绝密宝匣已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">绝密宝匣已完成</font>"
+        }
     },
     "top_secret_treasure_box_log": {
         "max_hit": 20,
@@ -332,7 +356,9 @@
             "top_secret_treasure_box_log"
         ],
         "on_error": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">进入绝密宝匣奖励记录</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入绝密宝匣奖励记录</font>"
+        }
     },
     "top_secret_treasure_box_copper": {
         "max_hit": 5,

--- a/assets/resource/base/pipeline/Headhunt.json
+++ b/assets/resource/base/pipeline/Headhunt.json
@@ -6,7 +6,7 @@
             "headhunt_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入招募任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入招募任务</font>"
     },
     "headhunt_entry": {
         "recognition": "TemplateMatch",
@@ -63,7 +63,7 @@
             "headhunt_recruit_enter",
             "[JumpBack]swipe_for_headhunt_recruit_enter"
         ],
-        "focus": "[color:DeepSkyBlue]没有免费高级招募[/color]",
+        "focus": "<font color=\"DeepSkyBlue\">没有免费高级招募</font>",
         "$doc": "因为高招有动画,所以这里不设post_wait_freezes"
     },
     "free_headhunt_waiting": {
@@ -86,7 +86,7 @@
             "free_headhunt_waiting",
             "[JumpBack]headhunt_whole_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]有免费高级招募[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">有免费高级招募</font>"
     },
     "headhunt_whole_ninja": {
         "recognition": "TemplateMatch",
@@ -101,7 +101,7 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]整卡![/color]"
+        "focus": "<font color=\"DeepSkyBlue\">整卡!</font>"
     },
     "free_headhunt_fake": {
         "recognition": "OCR",
@@ -118,7 +118,7 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "[color:DarkGoldenRod]什么,情报是假的[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">什么,情报是假的</font>"
     },
     "confirm_free_headhunt": {
         "max_hit": 5,
@@ -138,7 +138,7 @@
             "without_confirm_free_headhunt",
             "confirm_free_headhunt"
         ],
-        "focus": "[color:DeepSkyBlue]确认免费高级招募[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认免费高级招募</font>"
     },
     "without_confirm_free_headhunt": {
         "recognition": "TemplateMatch",
@@ -153,7 +153,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": [],
-        "focus": "[color:DeepSkyBlue]完成免费高级招募[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">完成免费高级招募</font>"
     },
     "swipe_for_headhunt_recruit_enter": {
         "max_hit": 3,
@@ -206,7 +206,7 @@
             "headhunt_recruit_no_free",
             "[JumpBack]headhunt_recruit"
         ],
-        "focus": "[color:DeepSkyBlue]进入普通招募[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入普通招募</font>"
     },
     "headhunt_recruit_no_free": {
         "recognition": "TemplateMatch",
@@ -227,7 +227,7 @@
             "top_secret_treasure_box_undone",
             "top_secret_treasure_box_done"
         ],
-        "focus": "[color:DeepSkyBlue]免费普通招募已使用[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">免费普通招募已使用</font>"
     },
     "headhunt_recruit": {
         "recognition": "TemplateMatch",
@@ -251,7 +251,7 @@
             "headhunt_recruit",
             "[JumpBack]headhunt_whole_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]进行免费普通招募[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进行免费普通招募</font>"
     },
     "confirm_headhunt_recruit": {
         "recognition": "OCR",
@@ -292,7 +292,7 @@
             "top_secret_treasure_box_log",
             "top_secret_treasure_box_undone"
         ],
-        "focus": "[color:DeepSkyBlue]绝密宝匣未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">绝密宝匣未完成</font>"
     },
     "top_secret_treasure_box_done": {
         "recognition": "TemplateMatch",
@@ -310,7 +310,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]绝密宝匣已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">绝密宝匣已完成</font>"
     },
     "top_secret_treasure_box_log": {
         "max_hit": 20,
@@ -332,7 +332,7 @@
             "top_secret_treasure_box_log"
         ],
         "on_error": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]进入绝密宝匣奖励记录[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入绝密宝匣奖励记录</font>"
     },
     "top_secret_treasure_box_copper": {
         "max_hit": 5,

--- a/assets/resource/base/pipeline/Hundred_ninja.json
+++ b/assets/resource/base/pipeline/Hundred_ninja.json
@@ -5,7 +5,7 @@
             "[JumpBack]hundred_ninja_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入百忍任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入百忍任务</font>"
     },
     "hundred_ninja_entry": {
         "recognition": "TemplateMatch",
@@ -16,7 +16,7 @@
         "next": [
             "hundred_ninja_more_game_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入决斗场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
     },
     "hundred_ninja_more_game_entry": {
         "recognition": "OCR",
@@ -34,7 +34,7 @@
         "next": [
             "hundred_ninja_icon"
         ],
-        "focus": "[color:DeepSkyBlue]进入更多玩法[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入更多玩法</font>"
     },
     "hundred_ninja_icon": {
         "recognition": "TemplateMatch",
@@ -47,7 +47,7 @@
         "template": "Hundred_ninja/entry.png",
         "action": "Click",
         "post_wait_freezes": 1000,
-        "focus": "[color:DeepSkyBlue]进入百忍对决[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入百忍对决</font>"
     },
     "hundred_ninja_match": {
         "recognition": "TemplateMatch",
@@ -503,7 +503,7 @@
         "next": [
             "hundred_ninja_entrance_animation"
         ],
-        "focus": "[color:DeepSkyBlue]匹配结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">匹配结束</font>"
     },
     "hundred_ninja_entrance_animation": {
         "recognition": "OCR",
@@ -523,7 +523,7 @@
             "hundred_ninja_out_entrance_animation",
             "hundred_ninja_entrance_animation"
         ],
-        "focus": "[color:DeepSkyBlue]百忍进场动画[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">百忍进场动画</font>"
     },
     "hundred_ninja_out_entrance_animation": {
         "recognition": "OCR",
@@ -545,7 +545,7 @@
             "hundred_ninja_selcet_ninja",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]离开百忍进场动画[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">离开百忍进场动画</font>"
     },
     "hundred_ninja_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -567,7 +567,7 @@
             "[JumpBack]hundred_ninja_selcet_ninja",
             "hundred_ninja_check_fight"
         ],
-        "focus": "[color:DeepSkyBlue]进入百忍选忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入百忍选忍者</font>"
     },
     "hundred_ninja_battle_tips": {
         "recognition": "TemplateMatch",
@@ -581,7 +581,7 @@
         "next": [
             "hundred_ninja_tips_confirm"
         ],
-        "focus": "[color:DeepSkyBlue]战斗异常提示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
     },
     "hundred_ninja_tips_confirm": {
         "recognition": "OCR",
@@ -630,7 +630,7 @@
             "hundred_ninja_battle_tips",
             "[JumpBack]hundred_ninja_selcet_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]百忍对决确定选忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">百忍对决确定选忍者</font>"
     },
     "hundred_ninja_fight": {
         "recognition": "TemplateMatch",
@@ -649,7 +649,7 @@
             "[JumpBack]hundred_ninja_click_All_skill",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]百忍对决战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
     },
     "hundred_ninja_check_fight": {
         "recognition": "TemplateMatch",
@@ -668,7 +668,7 @@
             "[JumpBack]hundred_ninja_check_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]百忍对决战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
     },
     "wait_5_second": {
         "post_delay": 5000
@@ -691,7 +691,7 @@
             "hundred_ninja_check_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]检测百忍对决不在战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测百忍对决不在战斗</font>"
     },
     "hundred_ninja_windfall": {
         "recognition": "OCR",
@@ -711,7 +711,7 @@
             "[JumpBack]hundred_ninja_windfall",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]赢了![/color]"
+        "focus": "<font color=\"DeepSkyBlue\">赢了!</font>"
     },
     "hundred_ninja_confirm_game_over": {
         "recognition": "OCR",
@@ -731,7 +731,7 @@
             "hundred_ninja_match",
             "[JumpBack]hundred_ninja_confirm_game_over"
         ],
-        "focus": "[color:DeepSkyBlue]百忍对决战斗结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗结束</font>"
     },
     "hundred_ninja_click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Hundred_ninja.json
+++ b/assets/resource/base/pipeline/Hundred_ninja.json
@@ -5,7 +5,9 @@
             "[JumpBack]hundred_ninja_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入百忍任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入百忍任务</font>"
+        }
     },
     "hundred_ninja_entry": {
         "recognition": "TemplateMatch",
@@ -16,7 +18,9 @@
         "next": [
             "hundred_ninja_more_game_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        }
     },
     "hundred_ninja_more_game_entry": {
         "recognition": "OCR",
@@ -34,7 +38,9 @@
         "next": [
             "hundred_ninja_icon"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入更多玩法</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入更多玩法</font>"
+        }
     },
     "hundred_ninja_icon": {
         "recognition": "TemplateMatch",
@@ -47,7 +53,9 @@
         "template": "Hundred_ninja/entry.png",
         "action": "Click",
         "post_wait_freezes": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">进入百忍对决</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入百忍对决</font>"
+        }
     },
     "hundred_ninja_match": {
         "recognition": "TemplateMatch",
@@ -503,7 +511,9 @@
         "next": [
             "hundred_ninja_entrance_animation"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">匹配结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">匹配结束</font>"
+        }
     },
     "hundred_ninja_entrance_animation": {
         "recognition": "OCR",
@@ -523,7 +533,9 @@
             "hundred_ninja_out_entrance_animation",
             "hundred_ninja_entrance_animation"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">百忍进场动画</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">百忍进场动画</font>"
+        }
     },
     "hundred_ninja_out_entrance_animation": {
         "recognition": "OCR",
@@ -545,7 +557,9 @@
             "hundred_ninja_selcet_ninja",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">离开百忍进场动画</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">离开百忍进场动画</font>"
+        }
     },
     "hundred_ninja_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -567,7 +581,9 @@
             "[JumpBack]hundred_ninja_selcet_ninja",
             "hundred_ninja_check_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入百忍选忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入百忍选忍者</font>"
+        }
     },
     "hundred_ninja_battle_tips": {
         "recognition": "TemplateMatch",
@@ -581,7 +597,9 @@
         "next": [
             "hundred_ninja_tips_confirm"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
+        }
     },
     "hundred_ninja_tips_confirm": {
         "recognition": "OCR",
@@ -630,7 +648,9 @@
             "hundred_ninja_battle_tips",
             "[JumpBack]hundred_ninja_selcet_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">百忍对决确定选忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">百忍对决确定选忍者</font>"
+        }
     },
     "hundred_ninja_fight": {
         "recognition": "TemplateMatch",
@@ -649,7 +669,9 @@
             "[JumpBack]hundred_ninja_click_All_skill",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
+        }
     },
     "hundred_ninja_check_fight": {
         "recognition": "TemplateMatch",
@@ -668,7 +690,9 @@
             "[JumpBack]hundred_ninja_check_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">百忍对决战斗</font>"
+        }
     },
     "wait_5_second": {
         "post_delay": 5000
@@ -691,7 +715,9 @@
             "hundred_ninja_check_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测百忍对决不在战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测百忍对决不在战斗</font>"
+        }
     },
     "hundred_ninja_windfall": {
         "recognition": "OCR",
@@ -711,7 +737,9 @@
             "[JumpBack]hundred_ninja_windfall",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">赢了!</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">赢了!</font>"
+        }
     },
     "hundred_ninja_confirm_game_over": {
         "recognition": "OCR",
@@ -731,7 +759,9 @@
             "hundred_ninja_match",
             "[JumpBack]hundred_ninja_confirm_game_over"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">百忍对决战斗结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">百忍对决战斗结束</font>"
+        }
     },
     "hundred_ninja_click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Joy_club.json
+++ b/assets/resource/base/pipeline/Joy_club.json
@@ -7,7 +7,9 @@
             "joy_club_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入心悦俱乐部子任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入心悦俱乐部子任务</font>"
+        }
     },
     "joy_club_enter": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Joy_club.json
+++ b/assets/resource/base/pipeline/Joy_club.json
@@ -7,7 +7,7 @@
             "joy_club_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入心悦俱乐部子任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入心悦俱乐部子任务</font>"
     },
     "joy_club_enter": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Konoha_question_and_answer.json
+++ b/assets/resource/base/pipeline/Konoha_question_and_answer.json
@@ -7,7 +7,7 @@
             "konoha_question_and_answer_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入问答子任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入问答子任务</font>"
     },
     "konoha_question_and_answer_entry": {
         "recognition": "TemplateMatch",
@@ -50,7 +50,7 @@
         "next": [
             "konoha_question_and_answer_match"
         ],
-        "focus": "[color:DeepSkyBlue]进入问答游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入问答游戏</font>"
     },
     "find_konoha_konoha_question_and_answer": {
         "recognition": "OCR",
@@ -71,7 +71,7 @@
             "konoha_question_and_answer_start",
             "[JumpBack]find_konoha_konoha_question_and_answer"
         ],
-        "focus": "[color:DeepSkyBlue]找到木叶问答[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到木叶问答</font>"
     },
     "swipes_for_konoha_question_and_answer": {
         "max_hit": 5,

--- a/assets/resource/base/pipeline/Konoha_question_and_answer.json
+++ b/assets/resource/base/pipeline/Konoha_question_and_answer.json
@@ -7,7 +7,9 @@
             "konoha_question_and_answer_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入问答子任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入问答子任务</font>"
+        }
     },
     "konoha_question_and_answer_entry": {
         "recognition": "TemplateMatch",
@@ -50,7 +52,9 @@
         "next": [
             "konoha_question_and_answer_match"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入问答游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入问答游戏</font>"
+        }
     },
     "find_konoha_konoha_question_and_answer": {
         "recognition": "OCR",
@@ -71,7 +75,9 @@
             "konoha_question_and_answer_start",
             "[JumpBack]find_konoha_konoha_question_and_answer"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到木叶问答</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到木叶问答</font>"
+        }
     },
     "swipes_for_konoha_question_and_answer": {
         "max_hit": 5,

--- a/assets/resource/base/pipeline/Leaderboard.json
+++ b/assets/resource/base/pipeline/Leaderboard.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入排行榜任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入排行榜任务</font>"
+        }
     },
     "ninja_guide_to_leaderboard": {
         "recognition": "Custom",
@@ -48,7 +50,9 @@
             "[JumpBack]click_thumb",
             "retry_failed"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">在排行榜中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">在排行榜中</font>"
+        }
     },
     "click_thumb": {
         "max_hit": 5,
@@ -90,6 +94,8 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点赞完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点赞完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Leaderboard.json
+++ b/assets/resource/base/pipeline/Leaderboard.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入排行榜任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入排行榜任务</font>"
     },
     "ninja_guide_to_leaderboard": {
         "recognition": "Custom",
@@ -48,7 +48,7 @@
             "[JumpBack]click_thumb",
             "retry_failed"
         ],
-        "focus": "[color:DeepSkyBlue]在排行榜中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">在排行榜中</font>"
     },
     "click_thumb": {
         "max_hit": 5,
@@ -90,6 +90,6 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]点赞完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点赞完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Liveness_award.json
+++ b/assets/resource/base/pipeline/Liveness_award.json
@@ -7,7 +7,7 @@
             "liveness_award_in_center_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入活跃度宝箱任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活跃度宝箱任务</font>"
     },
     "liveness_award_undone": {
         "recognition": "TemplateMatch",
@@ -63,7 +63,7 @@
             "liveness_award_in_center_enter",
             "liveness_award_not_in_center_enter"
         ],
-        "focus": "[color:DeepSkyBlue]奖励中心有奖励没领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
     },
     "liveness_award_done": {
         "pre_delay": 0,
@@ -72,7 +72,7 @@
             "weekly_liveness_award_undone",
             "weekly_liveness_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]活跃度宝箱已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">活跃度宝箱已领取</font>"
     },
     "get_liveness_award": {
         "recognition": "TemplateMatch",
@@ -93,7 +93,7 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]领取活跃度宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
     },
     "liveness_award_box_1_done": {
         "recognition": "TemplateMatch",
@@ -136,7 +136,7 @@
             "liveness_award_box_1_done",
             "get_liveness_award_box_1"
         ],
-        "focus": "[color:DeepSkyBlue]领取活跃度宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
     },
     "liveness_award_box_2_done": {
         "recognition": "TemplateMatch",
@@ -179,7 +179,7 @@
             "liveness_award_box_2_done",
             "get_liveness_award_box_2"
         ],
-        "focus": "[color:DeepSkyBlue]领取活跃度宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
     },
     "liveness_award_box_3_done": {
         "recognition": "TemplateMatch",
@@ -222,7 +222,7 @@
             "liveness_award_box_3_done",
             "get_liveness_award_box_3"
         ],
-        "focus": "[color:DeepSkyBlue]领取活跃度宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
     },
     "liveness_award_box_4_done": {
         "recognition": "TemplateMatch",
@@ -263,7 +263,7 @@
             "liveness_award_box_4_done",
             "get_liveness_award_box_4"
         ],
-        "focus": "[color:DeepSkyBlue]领取活跃度宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
     },
     "liveness_award_box_1_locked": {
         "recognition": "TemplateMatch",
@@ -371,7 +371,7 @@
             "confirm_weekly_liveness_award",
             "weekly_liveness_award_undone"
         ],
-        "focus": "[color:DeepSkyBlue]周度500活跃奖励可领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">周度500活跃奖励可领取</font>"
     },
     "confirm_weekly_liveness_award": {
         "recognition": "TemplateMatch",
@@ -386,7 +386,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]确认领取周度500活跃奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取周度500活跃奖励</font>"
     },
     "weekly_liveness_award_done": {
         "recognition": "TemplateMatch",
@@ -401,6 +401,6 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]周度500活跃奖励不可领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">周度500活跃奖励不可领取</font>"
     }
 }

--- a/assets/resource/base/pipeline/Liveness_award.json
+++ b/assets/resource/base/pipeline/Liveness_award.json
@@ -7,7 +7,9 @@
             "liveness_award_in_center_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活跃度宝箱任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活跃度宝箱任务</font>"
+        }
     },
     "liveness_award_undone": {
         "recognition": "TemplateMatch",
@@ -63,7 +65,9 @@
             "liveness_award_in_center_enter",
             "liveness_award_not_in_center_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        }
     },
     "liveness_award_done": {
         "pre_delay": 0,
@@ -72,7 +76,9 @@
             "weekly_liveness_award_undone",
             "weekly_liveness_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">活跃度宝箱已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">活跃度宝箱已领取</font>"
+        }
     },
     "get_liveness_award": {
         "recognition": "TemplateMatch",
@@ -93,7 +99,9 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        }
     },
     "liveness_award_box_1_done": {
         "recognition": "TemplateMatch",
@@ -136,7 +144,9 @@
             "liveness_award_box_1_done",
             "get_liveness_award_box_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        }
     },
     "liveness_award_box_2_done": {
         "recognition": "TemplateMatch",
@@ -179,7 +189,9 @@
             "liveness_award_box_2_done",
             "get_liveness_award_box_2"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        }
     },
     "liveness_award_box_3_done": {
         "recognition": "TemplateMatch",
@@ -222,7 +234,9 @@
             "liveness_award_box_3_done",
             "get_liveness_award_box_3"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        }
     },
     "liveness_award_box_4_done": {
         "recognition": "TemplateMatch",
@@ -263,7 +277,9 @@
             "liveness_award_box_4_done",
             "get_liveness_award_box_4"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度宝箱</font>"
+        }
     },
     "liveness_award_box_1_locked": {
         "recognition": "TemplateMatch",
@@ -371,7 +387,9 @@
             "confirm_weekly_liveness_award",
             "weekly_liveness_award_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">周度500活跃奖励可领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">周度500活跃奖励可领取</font>"
+        }
     },
     "confirm_weekly_liveness_award": {
         "recognition": "TemplateMatch",
@@ -386,7 +404,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认领取周度500活跃奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取周度500活跃奖励</font>"
+        }
     },
     "weekly_liveness_award_done": {
         "recognition": "TemplateMatch",
@@ -401,6 +421,8 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">周度500活跃奖励不可领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">周度500活跃奖励不可领取</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Mail.json
+++ b/assets/resource/base/pipeline/Mail.json
@@ -6,7 +6,9 @@
             "mail_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入领取邮箱奖励任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入领取邮箱奖励任务</font>"
+        }
     },
     "mail_entry": {
         "next": [
@@ -20,7 +22,9 @@
         "template": "Mail/mail_done.png",
         "threshold": 0.9,
         "action": "StopTask",
-        "focus": "<font color=\"DeepSkyBlue\">无邮箱奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">无邮箱奖励</font>"
+        }
     },
     "open_mail": {
         "recognition": "TemplateMatch",
@@ -43,7 +47,9 @@
             "get_mail_award",
             "open_mail"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">打开邮箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开邮箱</font>"
+        }
     },
     "get_mail_award": {
         "recognition": "OCR",
@@ -60,6 +66,8 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取邮箱奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取邮箱奖励</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Mail.json
+++ b/assets/resource/base/pipeline/Mail.json
@@ -6,7 +6,7 @@
             "mail_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入领取邮箱奖励任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入领取邮箱奖励任务</font>"
     },
     "mail_entry": {
         "next": [
@@ -20,7 +20,7 @@
         "template": "Mail/mail_done.png",
         "threshold": 0.9,
         "action": "StopTask",
-        "focus": "[color:DeepSkyBlue]无邮箱奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">无邮箱奖励</font>"
     },
     "open_mail": {
         "recognition": "TemplateMatch",
@@ -43,7 +43,7 @@
             "get_mail_award",
             "open_mail"
         ],
-        "focus": "[color:DeepSkyBlue]打开邮箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开邮箱</font>"
     },
     "get_mail_award": {
         "recognition": "OCR",
@@ -60,6 +60,6 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]领取邮箱奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取邮箱奖励</font>"
     }
 }

--- a/assets/resource/base/pipeline/Mission_office.json
+++ b/assets/resource/base/pipeline/Mission_office.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入任务集会所任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入任务集会所任务</font>"
     },
     "mission_office_in_ninja_guide": {
         "recognition": "Custom",
@@ -24,7 +24,7 @@
             "check_in_mission_office",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在忍界指引[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在忍界指引</font>"
     },
     "check_in_mission_office": {
         "recognition": "TemplateMatch",
@@ -41,7 +41,7 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "[color:DeepSkyBlue]已在任务集会所[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已在任务集会所</font>"
     },
     "check_no_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -60,7 +60,7 @@
             "mission_office_get_mission",
             "[JumpBack]celebrate_mission_office_award"
         ],
-        "focus": "[color:DeepSkyBlue]检测有没有任务集会所奖励可领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测有没有任务集会所奖励可领取</font>"
     },
     "get_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -80,7 +80,7 @@
             "[JumpBack]celebrate_mission_office_award",
             "get_mission_office_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取任务集会所奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取任务集会所奖励</font>"
     },
     "confirm_mission_office_award": {
         "recognition": "OCR",
@@ -102,7 +102,7 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "[color:DeepSkyBlue]确认领取任务集会所奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取任务集会所奖励</font>"
     },
     "celebrate_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -121,7 +121,7 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "[color:DeepSkyBlue]关闭任务集会所奖励界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭任务集会所奖励界面</font>"
     },
     "mission_office_get_mission": {
         "recognition": "TemplateMatch",
@@ -143,7 +143,7 @@
             "[JumpBack]mission_office_complete",
             "[JumpBack]take_mission_done"
         ],
-        "focus": "[color:DeepSkyBlue]接任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">接任务</font>"
     },
     "mission_office_complete": {
         "recognition": "OCR",
@@ -161,7 +161,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]任务已领完[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务已领完</font>"
     },
     "mission_office_3_advance_mission": {
         "recognition": "TemplateMatch",
@@ -190,7 +190,7 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_3_advance_mission"
         ],
-        "focus": "[color:DeepSkyBlue]接高级任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">接高级任务</font>"
     },
     "mission_office_recommended_team": {
         "recognition": "TemplateMatch",
@@ -210,7 +210,7 @@
             "mission_office_no_recommended_team",
             "[JumpBack]mission_office_recommended_team"
         ],
-        "focus": "[color:DeepSkyBlue]使用推荐配队[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
     },
     "mission_office_no_recommended_team": {
         "recognition": "OCR",
@@ -291,7 +291,7 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_3_mission"
         ],
-        "focus": "[color:DeepSkyBlue]接三人任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">接三人任务</font>"
     },
     "mission_office_Sharingan_mission": {
         "recognition": "TemplateMatch",
@@ -346,7 +346,7 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_relation_mission"
         ],
-        "focus": "[color:DeepSkyBlue]接羁绊任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">接羁绊任务</font>"
     },
     "take_mission_office_relation_mission": {
         "pre_delay": 0,
@@ -681,7 +681,7 @@
             "select_ninja_for_solo_mission_by_frame",
             "[JumpBack]mission_office_solo_mission"
         ],
-        "focus": "[color:DeepSkyBlue]接单人任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">接单人任务</font>"
     },
     "tack_mission_office_solo_mission": {
         "pre_delay": 0,
@@ -1189,7 +1189,7 @@
             "mission_office_greedy_strategy",
             "mission_office_safe_strategy"
         ],
-        "focus": "[color:DeepSkyBlue]任务集会所超影模式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务集会所超影模式</font>"
     },
     "mission_office_greedy_strategy": {
         "recognition": "Custom",
@@ -1405,7 +1405,7 @@
             "mission_office_above_kage_recommended_team_check",
             "[JumpBack]mission_office_above_kage_recommended_team"
         ],
-        "focus": "[color:DeepSkyBlue]使用推荐配队[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
     },
     "mission_office_above_kage_no_recommended_team": {
         "recognition": "OCR",
@@ -1542,7 +1542,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]任务已经接取完毕[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
     },
     "above_kage_take_mission_done": {
         "recognition": "TemplateMatch",
@@ -1559,7 +1559,7 @@
             "mission_office_gold_refresh",
             "mission_office_above_kage_refresh"
         ],
-        "focus": "[color:DeepSkyBlue]任务已经接取完毕[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
     },
     "mission_office_above_kage_refresh": {
         "recognition": "TemplateMatch",
@@ -1577,7 +1577,7 @@
         "next": [
             "check_mission_office_reflash_done"
         ],
-        "focus": "[color:DeepSkyBlue]任务集会所超影刷新[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务集会所超影刷新</font>"
     },
     "mission_office_gold_refresh": {
         "recognition": "TemplateMatch",
@@ -1613,7 +1613,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "mission_office_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1639,6 +1639,6 @@
             "check_in_mission_office",
             "[JumpBack]mission_office_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]任务集会所未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务集会所未完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Mission_office.json
+++ b/assets/resource/base/pipeline/Mission_office.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入任务集会所任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入任务集会所任务</font>"
+        }
     },
     "mission_office_in_ninja_guide": {
         "recognition": "Custom",
@@ -24,7 +26,9 @@
             "check_in_mission_office",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在忍界指引</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在忍界指引</font>"
+        }
     },
     "check_in_mission_office": {
         "recognition": "TemplateMatch",
@@ -41,7 +45,9 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已在任务集会所</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已在任务集会所</font>"
+        }
     },
     "check_no_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -60,7 +66,9 @@
             "mission_office_get_mission",
             "[JumpBack]celebrate_mission_office_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测有没有任务集会所奖励可领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测有没有任务集会所奖励可领取</font>"
+        }
     },
     "get_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -80,7 +88,9 @@
             "[JumpBack]celebrate_mission_office_award",
             "get_mission_office_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取任务集会所奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取任务集会所奖励</font>"
+        }
     },
     "confirm_mission_office_award": {
         "recognition": "OCR",
@@ -102,7 +112,9 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认领取任务集会所奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取任务集会所奖励</font>"
+        }
     },
     "celebrate_mission_office_award": {
         "recognition": "TemplateMatch",
@@ -121,7 +133,9 @@
             "check_no_mission_office_award",
             "[JumpBack]get_mission_office_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭任务集会所奖励界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭任务集会所奖励界面</font>"
+        }
     },
     "mission_office_get_mission": {
         "recognition": "TemplateMatch",
@@ -143,7 +157,9 @@
             "[JumpBack]mission_office_complete",
             "[JumpBack]take_mission_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">接任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">接任务</font>"
+        }
     },
     "mission_office_complete": {
         "recognition": "OCR",
@@ -161,7 +177,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务已领完</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务已领完</font>"
+        }
     },
     "mission_office_3_advance_mission": {
         "recognition": "TemplateMatch",
@@ -190,7 +208,9 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_3_advance_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">接高级任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">接高级任务</font>"
+        }
     },
     "mission_office_recommended_team": {
         "recognition": "TemplateMatch",
@@ -210,7 +230,9 @@
             "mission_office_no_recommended_team",
             "[JumpBack]mission_office_recommended_team"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
+        }
     },
     "mission_office_no_recommended_team": {
         "recognition": "OCR",
@@ -291,7 +313,9 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_3_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">接三人任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">接三人任务</font>"
+        }
     },
     "mission_office_Sharingan_mission": {
         "recognition": "TemplateMatch",
@@ -346,7 +370,9 @@
             "mission_office_recommended_team",
             "[JumpBack]mission_office_relation_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">接羁绊任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">接羁绊任务</font>"
+        }
     },
     "take_mission_office_relation_mission": {
         "pre_delay": 0,
@@ -681,7 +707,9 @@
             "select_ninja_for_solo_mission_by_frame",
             "[JumpBack]mission_office_solo_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">接单人任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">接单人任务</font>"
+        }
     },
     "tack_mission_office_solo_mission": {
         "pre_delay": 0,
@@ -1189,7 +1217,9 @@
             "mission_office_greedy_strategy",
             "mission_office_safe_strategy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务集会所超影模式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务集会所超影模式</font>"
+        }
     },
     "mission_office_greedy_strategy": {
         "recognition": "Custom",
@@ -1405,7 +1435,9 @@
             "mission_office_above_kage_recommended_team_check",
             "[JumpBack]mission_office_above_kage_recommended_team"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">使用推荐配队</font>"
+        }
     },
     "mission_office_above_kage_no_recommended_team": {
         "recognition": "OCR",
@@ -1542,7 +1574,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
+        }
     },
     "above_kage_take_mission_done": {
         "recognition": "TemplateMatch",
@@ -1559,7 +1593,9 @@
             "mission_office_gold_refresh",
             "mission_office_above_kage_refresh"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务已经接取完毕</font>"
+        }
     },
     "mission_office_above_kage_refresh": {
         "recognition": "TemplateMatch",
@@ -1577,7 +1613,9 @@
         "next": [
             "check_mission_office_reflash_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务集会所超影刷新</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务集会所超影刷新</font>"
+        }
     },
     "mission_office_gold_refresh": {
         "recognition": "TemplateMatch",
@@ -1613,7 +1651,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "mission_office_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1639,6 +1679,8 @@
             "check_in_mission_office",
             "[JumpBack]mission_office_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">任务集会所未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务集会所未完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/More_gameplay.json
+++ b/assets/resource/base/pipeline/More_gameplay.json
@@ -7,7 +7,7 @@
             "[JumpBack]more_gameplay_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]开始更多玩法任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始更多玩法任务</font>"
     },
     "more_gameplay_in_duel_field": {
         "recognition": "OCR",
@@ -29,7 +29,7 @@
             "[JumpBack]weekly_win_mouthly_award",
             "more_gameplay_to_select_gameplay"
         ],
-        "focus": "[color:DeepSkyBlue]已在决斗场界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
     },
     "more_gameplay_entry": {
         "recognition": "TemplateMatch",
@@ -46,7 +46,7 @@
             "more_gameplay_in_duel_field",
             "more_gameplay_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入决斗场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
     },
     "more_gameplay_to_select_gameplay": {
         "recognition": "OCR",
@@ -167,7 +167,7 @@
             "[JumpBack]swipe_for_select_more_gameplay",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:darkorange]百忍还没开,尝试玩别的[/color]"
+        "focus": "<font color=\"darkorange\">百忍还没开,尝试玩别的</font>"
     },
     "more_gameplay_trace_vanish": {
         "enabled": true,
@@ -487,7 +487,7 @@
             "more_gameplay_without_match_win",
             "[JumpBack]more_gameplay_match_win"
         ],
-        "focus": "[color:DeepSkyBlue]敌人退出了,你获胜[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
     },
     "more_gameplay_without_match_win": {
         "recognition": "TemplateMatch",
@@ -507,7 +507,7 @@
             "more_gameplay_trace_vanish_choose_ninja",
             "more_gameplay_trace_vanish_confirm_fight"
         ],
-        "focus": "[color:DeepSkyBlue]回到战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
     },
     "more_gameplay_trace_vanish_confirm_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -527,7 +527,7 @@
             "[JumpBack]more_gameplay_trace_vanish_confirm_selcet_ninja",
             "more_gameplay_in_trace_vanish"
         ],
-        "focus": "[color:DeepSkyBlue]绝迹战场确定选忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">绝迹战场确定选忍者</font>"
     },
     "more_gameplay_trace_vanish_without_confirm_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -581,7 +581,7 @@
             "[JumpBack]more_gameplay_All_skill",
             "more_gameplay_go_fight"
         ],
-        "focus": "[color:DeepSkyBlue]绝迹战场战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">绝迹战场战斗</font>"
     },
     "more_gameplay_trace_vanish_check_no_fight": {
         "recognition": "TemplateMatch",
@@ -601,7 +601,7 @@
             "[JumpBack]more_gameplay_trace_vanish_check_no_fight",
             "more_gameplay_go_fight"
         ],
-        "focus": "[color:DeepSkyBlue]绝迹战场战斗结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">绝迹战场战斗结束</font>"
     },
     "more_gameplay_All_skill": {
         "recognition": "TemplateMatch",
@@ -733,7 +733,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "more_gameplay_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -759,6 +759,6 @@
             "more_gameplay_in_select_gameplay",
             "more_gameplay_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]可以进入更多玩法[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">可以进入更多玩法</font>"
     }
 }

--- a/assets/resource/base/pipeline/More_gameplay.json
+++ b/assets/resource/base/pipeline/More_gameplay.json
@@ -7,7 +7,9 @@
             "[JumpBack]more_gameplay_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始更多玩法任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始更多玩法任务</font>"
+        }
     },
     "more_gameplay_in_duel_field": {
         "recognition": "OCR",
@@ -29,7 +31,9 @@
             "[JumpBack]weekly_win_mouthly_award",
             "more_gameplay_to_select_gameplay"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
+        }
     },
     "more_gameplay_entry": {
         "recognition": "TemplateMatch",
@@ -46,7 +50,9 @@
             "more_gameplay_in_duel_field",
             "more_gameplay_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        }
     },
     "more_gameplay_to_select_gameplay": {
         "recognition": "OCR",
@@ -167,7 +173,9 @@
             "[JumpBack]swipe_for_select_more_gameplay",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"darkorange\">百忍还没开,尝试玩别的</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkorange\">百忍还没开,尝试玩别的</font>"
+        }
     },
     "more_gameplay_trace_vanish": {
         "enabled": true,
@@ -487,7 +495,9 @@
             "more_gameplay_without_match_win",
             "[JumpBack]more_gameplay_match_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
+        }
     },
     "more_gameplay_without_match_win": {
         "recognition": "TemplateMatch",
@@ -507,7 +517,9 @@
             "more_gameplay_trace_vanish_choose_ninja",
             "more_gameplay_trace_vanish_confirm_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        }
     },
     "more_gameplay_trace_vanish_confirm_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -527,7 +539,9 @@
             "[JumpBack]more_gameplay_trace_vanish_confirm_selcet_ninja",
             "more_gameplay_in_trace_vanish"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">绝迹战场确定选忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">绝迹战场确定选忍者</font>"
+        }
     },
     "more_gameplay_trace_vanish_without_confirm_selcet_ninja": {
         "recognition": "TemplateMatch",
@@ -581,7 +595,9 @@
             "[JumpBack]more_gameplay_All_skill",
             "more_gameplay_go_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">绝迹战场战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">绝迹战场战斗</font>"
+        }
     },
     "more_gameplay_trace_vanish_check_no_fight": {
         "recognition": "TemplateMatch",
@@ -601,7 +617,9 @@
             "[JumpBack]more_gameplay_trace_vanish_check_no_fight",
             "more_gameplay_go_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">绝迹战场战斗结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">绝迹战场战斗结束</font>"
+        }
     },
     "more_gameplay_All_skill": {
         "recognition": "TemplateMatch",
@@ -733,7 +751,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "more_gameplay_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -759,6 +779,8 @@
             "more_gameplay_in_select_gameplay",
             "more_gameplay_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">可以进入更多玩法</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">可以进入更多玩法</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Naruto_club.json
+++ b/assets/resource/base/pipeline/Naruto_club.json
@@ -6,7 +6,9 @@
             "click_club_icon",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入情报社任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入情报社任务</font>"
+        }
     },
     "click_club_icon": {
         "recognition": "TemplateMatch",
@@ -30,7 +32,9 @@
             "[JumpBack]without_naruto_club",
             "unknow_error"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击情报社</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击情报社</font>"
+        }
     },
     "without_naruto_club": {
         "max_hit": 10,
@@ -61,7 +65,9 @@
         "next": [
             "confirm_naruto_club_too_many_people"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">情报社访问人数过多</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">情报社访问人数过多</font>"
+        }
     },
     "confirm_naruto_club_too_many_people": {
         "recognition": "OCR",
@@ -114,7 +120,9 @@
             "[JumpBack]surf_post_try_reflash_to_follow",
             "try_esc"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">从没有话题的地狱回来了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">从没有话题的地狱回来了</font>"
+        }
     },
     "surf_post_try_reflash_in_follow": {
         "recognition": "TemplateMatch",
@@ -178,7 +186,9 @@
         "next": [
             "club_like_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否开始话题冲浪</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否开始话题冲浪</font>"
+        }
     },
     "surf_post": {
         "max_hit": 8,
@@ -196,7 +206,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_wait_freezes": 500,
-        "focus": "<font color=\"DeepSkyBlue\">选择有评论话题</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择有评论话题</font>"
+        }
     },
     "club_like_mission": {
         "next": [
@@ -223,7 +235,9 @@
             "cancel_club_has_follow",
             "cancel_club_follow"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">取消误关注</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">取消误关注</font>"
+        }
     },
     "cancel_club_has_follow": {
         "recognition": "OCR",
@@ -251,7 +265,9 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第一个点赞任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第一个点赞任务</font>"
+        }
     },
     "swipe_for_club_like": {
         "action": "Swipe",
@@ -269,7 +285,9 @@
         ],
         "post_delay": 1500,
         "timeout": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">滑动点赞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">滑动点赞</font>"
+        }
     },
     "no_comment_now": {
         "recognition": "OCR",
@@ -284,7 +302,9 @@
             "surf_post_try_reflash_comment",
             "unknow_error"
         ],
-        "focus": "<font color=\"red\">暂无评论可供点赞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"red\">暂无评论可供点赞</font>"
+        }
     },
     "second_like": {
         "recognition": "TemplateMatch",
@@ -298,7 +318,9 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第二个点赞任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第二个点赞任务</font>"
+        }
     },
     "third_like": {
         "recognition": "TemplateMatch",
@@ -312,7 +334,9 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第三个点赞任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第三个点赞任务</font>"
+        }
     },
     "fourth_like": {
         "recognition": "TemplateMatch",
@@ -325,7 +349,9 @@
             "scroll",
             "fourth_like"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第四个点赞任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第四个点赞任务</font>"
+        }
     },
     "surf_post_try_reflash_comment": {
         "max_hit": 3,
@@ -348,7 +374,9 @@
             "surf_post_try_reflash",
             "unknow_error"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">没有评论的世界还有什么意义</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">没有评论的世界还有什么意义</font>"
+        }
     },
     "close_surf_post": {
         "recognition": "OCR",
@@ -367,7 +395,9 @@
             "scroll",
             "close_surf_post"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭话题</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭话题</font>"
+        }
     },
     "scroll": {
         "recognition": "OCR",
@@ -387,7 +417,9 @@
             "close_scroll",
             "scroll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入卷轴</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入卷轴</font>"
+        }
     },
     "close_scroll": {
         "recognition": "OCR",
@@ -407,7 +439,9 @@
             "ninja_station",
             "close_scroll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭卷轴</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭卷轴</font>"
+        }
     },
     "ninja_station": {
         "recognition": "OCR",
@@ -426,7 +460,9 @@
             "close_ninja_station",
             "ninja_station"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍者站</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍者站</font>"
+        }
     },
     "close_ninja_station": {
         "recognition": "OCR",
@@ -446,7 +482,9 @@
             "village_entry",
             "close_ninja_station"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭忍者站</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭忍者站</font>"
+        }
     },
     "village_entry": {
         "recognition": "OCR",
@@ -466,7 +504,9 @@
             "close_village_entry",
             "village_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入村口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入村口</font>"
+        }
     },
     "close_village_entry": {
         "max_hit": 5,
@@ -487,7 +527,9 @@
             "close_village_entry",
             "without_benefit_station"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭村口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭村口</font>"
+        }
     },
     "without_benefit_station": {
         "recognition": "TemplateMatch",
@@ -503,7 +545,9 @@
         "next": [
             "try_flash_benefit_station_by_village_entry"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">可以把福利站还给我吗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">可以把福利站还给我吗</font>"
+        }
     },
     "try_flash_benefit_station_by_village_entry": {
         "recognition": "OCR",
@@ -522,7 +566,9 @@
         "next": [
             "try_flash_benefit_station_close_village_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入村口刷新福利站</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入村口刷新福利站</font>"
+        }
     },
     "try_flash_benefit_station_close_village_entry": {
         "max_hit": 5,
@@ -544,7 +590,9 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭村口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭村口</font>"
+        }
     },
     "benefit_station": {
         "recognition": "TemplateMatch",
@@ -563,7 +611,9 @@
             "sign_done",
             "benefit_station"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入福利站</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入福利站</font>"
+        }
     },
     "sign_done": {
         "recognition": "OCR",
@@ -582,7 +632,9 @@
             "without_feed_pig",
             "check_club_mission_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">签到已经完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">签到已经完成</font>"
+        }
     },
     "naruto_club_sign": {
         "recognition": "OCR",
@@ -603,7 +655,9 @@
             "naruto_club_sign",
             "sign_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进行签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进行签到</font>"
+        }
     },
     "confirm_naruto_club_sign": {
         "recognition": "OCR",
@@ -624,7 +678,9 @@
             "confirm_naruto_club_sign",
             "sign_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认签到</font>"
+        }
     },
     "roger_naruto_club_sign": {
         "recognition": "OCR",
@@ -646,7 +702,9 @@
             "check_club_mission_done",
             "sign_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">收到签到提醒</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">收到签到提醒</font>"
+        }
     },
     "without_feed_pig": {
         "recognition": "OCR",
@@ -657,7 +715,9 @@
         "next": [
             "check_club_mission_done"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">大事不妙雷霆猪</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">大事不妙雷霆猪</font>"
+        }
     },
     "feed_pig": {
         "recognition": "OCR",
@@ -676,7 +736,9 @@
             "feed_pig_work",
             "feed_pig"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">喂豚豚</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">喂豚豚</font>"
+        }
     },
     "feed_pig_work": {
         "recognition": "OCR",
@@ -693,13 +755,17 @@
         "on_error": [
             "feed_pig_not_found"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已进入喂豚豚</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已进入喂豚豚</font>"
+        }
     },
     "feed_pig_not_found": {
         "next": [
             "close_feed_pig"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">无法找到喂豚豚按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">无法找到喂豚豚按钮</font>"
+        }
     },
     "weekly_feed_pig": {
         "max_hit": 5,
@@ -715,7 +781,9 @@
             "feed_pig_done",
             "close_feed_pig"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击喂豚豚</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击喂豚豚</font>"
+        }
     },
     "feed_pig_done": {
         "recognition": "OCR",
@@ -727,7 +795,9 @@
         "next": [
             "close_feed_pig"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">喂豚豚已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">喂豚豚已完成</font>"
+        }
     },
     "confirm_feed_pig": {
         "recognition": "OCR",
@@ -739,7 +809,9 @@
         "next": [
             "close_feed_pig"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认喂豚豚</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认喂豚豚</font>"
+        }
     },
     "close_feed_pig": {
         "action": "ClickKey",
@@ -748,7 +820,9 @@
         "next": [
             "check_club_mission_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭喂豚豚</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭喂豚豚</font>"
+        }
     },
     "check_club_mission_done": {
         "next": [
@@ -791,13 +865,17 @@
             "gold_helper_done",
             "glod_helper_not_found"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">上滑动去金币助手</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">上滑动去金币助手</font>"
+        }
     },
     "glod_helper_not_found": {
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "<font color=\"red\">没有找到金币助手任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"red\">没有找到金币助手任务</font>"
+        }
     },
     "gold_helper_undone": {
         "recognition": "TemplateMatch",
@@ -814,7 +892,9 @@
         "next": [
             "close_gold_helper"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">金币助手未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">金币助手未完成</font>"
+        }
     },
     "gold_helper_wait": {
         "recognition": "TemplateMatch",
@@ -823,7 +903,9 @@
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">可以领取金币助手活跃度奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">可以领取金币助手活跃度奖励</font>"
+        }
     },
     "gold_helper_done": {
         "recognition": "TemplateMatch",
@@ -832,7 +914,9 @@
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">金币助手已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">金币助手已完成</font>"
+        }
     },
     "close_gold_helper": {
         "action": "ClickKey",
@@ -843,7 +927,9 @@
             "swipe_for_club_submit",
             "[JumpBack]close_gold_helper"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭金币助手</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭金币助手</font>"
+        }
     },
     "swipe_for_club_submit": {
         "recognition": "OCR",
@@ -895,7 +981,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DarkGoldenRod\">这里已经空了,可能是系统繁忙,退出请报社</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">这里已经空了,可能是系统繁忙,退出请报社</font>"
+        }
     },
     "check_club_all_submit": {
         "max_hit": 5,
@@ -919,7 +1007,9 @@
         "on_error": [
             "try_esc"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测任务是否已经全部提交</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测任务是否已经全部提交</font>"
+        }
     },
     "club_submit": {
         "recognition": "TemplateMatch",
@@ -953,7 +1043,9 @@
         "next": [
             "naruto_club_back_post"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">土豆</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">土豆</font>"
+        }
     },
     "naruto_club_back_post": {
         "max_hit": 9,
@@ -968,14 +1060,18 @@
             "benefit_station",
             "naruto_club_back_post"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">退回话题</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">退回话题</font>"
+        }
     },
     "start_qq": {
         "pre_delay": 1000,
         "action": "StartApp",
         "package": "com.tencent.mobileqq",
         "post_delay": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">打开qq</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开qq</font>"
+        }
     },
     "club_first_award_done": {
         "recognition": "TemplateMatch",
@@ -993,7 +1089,9 @@
             "club_second_award_done",
             "[JumpBack]club_second_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第一个奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第一个奖励已领取</font>"
+        }
     },
     "club_first_award": {
         "max_hit": 3,
@@ -1017,7 +1115,9 @@
             "club_first_award"
         ],
         "on_error": "naruto_club_in_loop_wheel",
-        "focus": "<font color=\"DeepSkyBlue\">领取第一个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取第一个奖励</font>"
+        }
     },
     "club_first_award_on_error": {
         "max_hit": 3,
@@ -1038,7 +1138,9 @@
             "confirm_club_first_award"
         ],
         "on_error": "naruto_club_in_loop_wheel",
-        "focus": "<font color=\"DeepSkyBlue\">第二次领取第一个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第二次领取第一个奖励</font>"
+        }
     },
     "confirm_club_first_award": {
         "recognition": "OCR",
@@ -1062,7 +1164,9 @@
         "on_error": [
             "naruto_club_in_loop_wheel"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认领取第一个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取第一个奖励</font>"
+        }
     },
     "roger_club_first_award": {
         "recognition": "OCR",
@@ -1090,7 +1194,9 @@
         "next": [
             "naruto_club_back_post"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">意志坚定</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">意志坚定</font>"
+        }
     },
     "club_second_award": {
         "recognition": "TemplateMatch",
@@ -1110,7 +1216,9 @@
             "club_second_award_done"
         ],
         "on_error": "award_kale",
-        "focus": "<font color=\"DeepSkyBlue\">领取第二个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取第二个奖励</font>"
+        }
     },
     "confirm_club_second_award": {
         "recognition": "OCR",
@@ -1131,7 +1239,9 @@
             "confirm_club_second_award",
             "club_second_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认领取第二个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取第二个奖励</font>"
+        }
     },
     "roger_club_second_award": {
         "recognition": "OCR",
@@ -1166,14 +1276,18 @@
         "on_error": [
             "no_third_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第二个奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第二个奖励已领取</font>"
+        }
     },
     "no_third_award": {
         "recognition": "DirectHit",
         "next": [
             "close_naruto_club"
         ],
-        "focus": "<font color=\"red\">无法领取第三奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"red\">无法领取第三奖励</font>"
+        }
     },
     "club_third_award": {
         "max_hit": 3,
@@ -1194,7 +1308,9 @@
             "[JumpBack]club_third_award",
             "club_third_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取第三个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取第三个奖励</font>"
+        }
     },
     "confirm_club_third_award": {
         "recognition": "OCR",
@@ -1214,7 +1330,9 @@
             "confirm_club_third_award",
             "club_third_award_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认领取第三个奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取第三个奖励</font>"
+        }
     },
     "roger_club_third_award": {
         "recognition": "OCR",
@@ -1248,7 +1366,9 @@
         "next": [
             "close_naruto_club"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">第三个奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">第三个奖励已领取</font>"
+        }
     },
     "close_naruto_club": {
         "recognition": "TemplateMatch",
@@ -1263,7 +1383,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
+        }
     },
     "shut_qq": {
         "pre_delay": 0,
@@ -1285,7 +1407,9 @@
     },
     "award_kale": {
         "action": "StopTask",
-        "focus": "<font color=\"DarkGoldenRod\">当前操作超时，疑似遇到真投入</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">当前操作超时，疑似遇到真投入</font>"
+        }
     },
     "try_esc": {
         "max_hit": 1,

--- a/assets/resource/base/pipeline/Naruto_club.json
+++ b/assets/resource/base/pipeline/Naruto_club.json
@@ -6,7 +6,7 @@
             "click_club_icon",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入情报社任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入情报社任务</font>"
     },
     "click_club_icon": {
         "recognition": "TemplateMatch",
@@ -30,7 +30,7 @@
             "[JumpBack]without_naruto_club",
             "unknow_error"
         ],
-        "focus": "[color:DeepSkyBlue]点击情报社[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击情报社</font>"
     },
     "without_naruto_club": {
         "max_hit": 10,
@@ -61,7 +61,7 @@
         "next": [
             "confirm_naruto_club_too_many_people"
         ],
-        "focus": "[color:DeepSkyBlue]情报社访问人数过多[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">情报社访问人数过多</font>"
     },
     "confirm_naruto_club_too_many_people": {
         "recognition": "OCR",
@@ -114,7 +114,7 @@
             "[JumpBack]surf_post_try_reflash_to_follow",
             "try_esc"
         ],
-        "focus": "[color:DarkGoldenRod]从没有话题的地狱回来了[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">从没有话题的地狱回来了</font>"
     },
     "surf_post_try_reflash_in_follow": {
         "recognition": "TemplateMatch",
@@ -178,7 +178,7 @@
         "next": [
             "club_like_mission"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否开始话题冲浪[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否开始话题冲浪</font>"
     },
     "surf_post": {
         "max_hit": 8,
@@ -196,7 +196,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_wait_freezes": 500,
-        "focus": "[color:DeepSkyBlue]选择有评论话题[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择有评论话题</font>"
     },
     "club_like_mission": {
         "next": [
@@ -223,7 +223,7 @@
             "cancel_club_has_follow",
             "cancel_club_follow"
         ],
-        "focus": "[color:DeepSkyBlue]取消误关注[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">取消误关注</font>"
     },
     "cancel_club_has_follow": {
         "recognition": "OCR",
@@ -251,7 +251,7 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "[color:DeepSkyBlue]第一个点赞任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第一个点赞任务</font>"
     },
     "swipe_for_club_like": {
         "action": "Swipe",
@@ -269,7 +269,7 @@
         ],
         "post_delay": 1500,
         "timeout": 1000,
-        "focus": "[color:DeepSkyBlue]滑动点赞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">滑动点赞</font>"
     },
     "no_comment_now": {
         "recognition": "OCR",
@@ -284,7 +284,7 @@
             "surf_post_try_reflash_comment",
             "unknow_error"
         ],
-        "focus": "[color:red]暂无评论可供点赞[/color]"
+        "focus": "<font color=\"red\">暂无评论可供点赞</font>"
     },
     "second_like": {
         "recognition": "TemplateMatch",
@@ -298,7 +298,7 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "[color:DeepSkyBlue]第二个点赞任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第二个点赞任务</font>"
     },
     "third_like": {
         "recognition": "TemplateMatch",
@@ -312,7 +312,7 @@
             "[JumpBack]cancel_club_follow",
             "[JumpBack]swipe_for_club_like"
         ],
-        "focus": "[color:DeepSkyBlue]第三个点赞任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第三个点赞任务</font>"
     },
     "fourth_like": {
         "recognition": "TemplateMatch",
@@ -325,7 +325,7 @@
             "scroll",
             "fourth_like"
         ],
-        "focus": "[color:DeepSkyBlue]第四个点赞任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第四个点赞任务</font>"
     },
     "surf_post_try_reflash_comment": {
         "max_hit": 3,
@@ -348,7 +348,7 @@
             "surf_post_try_reflash",
             "unknow_error"
         ],
-        "focus": "[color:DarkGoldenRod]没有评论的世界还有什么意义[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">没有评论的世界还有什么意义</font>"
     },
     "close_surf_post": {
         "recognition": "OCR",
@@ -367,7 +367,7 @@
             "scroll",
             "close_surf_post"
         ],
-        "focus": "[color:DeepSkyBlue]关闭话题[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭话题</font>"
     },
     "scroll": {
         "recognition": "OCR",
@@ -387,7 +387,7 @@
             "close_scroll",
             "scroll"
         ],
-        "focus": "[color:DeepSkyBlue]进入卷轴[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入卷轴</font>"
     },
     "close_scroll": {
         "recognition": "OCR",
@@ -407,7 +407,7 @@
             "ninja_station",
             "close_scroll"
         ],
-        "focus": "[color:DeepSkyBlue]关闭卷轴[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭卷轴</font>"
     },
     "ninja_station": {
         "recognition": "OCR",
@@ -426,7 +426,7 @@
             "close_ninja_station",
             "ninja_station"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍者站[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍者站</font>"
     },
     "close_ninja_station": {
         "recognition": "OCR",
@@ -446,7 +446,7 @@
             "village_entry",
             "close_ninja_station"
         ],
-        "focus": "[color:DeepSkyBlue]关闭忍者站[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭忍者站</font>"
     },
     "village_entry": {
         "recognition": "OCR",
@@ -466,7 +466,7 @@
             "close_village_entry",
             "village_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入村口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入村口</font>"
     },
     "close_village_entry": {
         "max_hit": 5,
@@ -487,7 +487,7 @@
             "close_village_entry",
             "without_benefit_station"
         ],
-        "focus": "[color:DeepSkyBlue]关闭村口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭村口</font>"
     },
     "without_benefit_station": {
         "recognition": "TemplateMatch",
@@ -503,7 +503,7 @@
         "next": [
             "try_flash_benefit_station_by_village_entry"
         ],
-        "focus": "[color:DarkGoldenRod]可以把福利站还给我吗[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">可以把福利站还给我吗</font>"
     },
     "try_flash_benefit_station_by_village_entry": {
         "recognition": "OCR",
@@ -522,7 +522,7 @@
         "next": [
             "try_flash_benefit_station_close_village_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入村口刷新福利站[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入村口刷新福利站</font>"
     },
     "try_flash_benefit_station_close_village_entry": {
         "max_hit": 5,
@@ -544,7 +544,7 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]关闭村口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭村口</font>"
     },
     "benefit_station": {
         "recognition": "TemplateMatch",
@@ -563,7 +563,7 @@
             "sign_done",
             "benefit_station"
         ],
-        "focus": "[color:DeepSkyBlue]进入福利站[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入福利站</font>"
     },
     "sign_done": {
         "recognition": "OCR",
@@ -582,7 +582,7 @@
             "without_feed_pig",
             "check_club_mission_done"
         ],
-        "focus": "[color:DeepSkyBlue]签到已经完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">签到已经完成</font>"
     },
     "naruto_club_sign": {
         "recognition": "OCR",
@@ -603,7 +603,7 @@
             "naruto_club_sign",
             "sign_done"
         ],
-        "focus": "[color:DeepSkyBlue]进行签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进行签到</font>"
     },
     "confirm_naruto_club_sign": {
         "recognition": "OCR",
@@ -624,7 +624,7 @@
             "confirm_naruto_club_sign",
             "sign_done"
         ],
-        "focus": "[color:DeepSkyBlue]确认签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认签到</font>"
     },
     "roger_naruto_club_sign": {
         "recognition": "OCR",
@@ -646,7 +646,7 @@
             "check_club_mission_done",
             "sign_done"
         ],
-        "focus": "[color:DeepSkyBlue]收到签到提醒[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">收到签到提醒</font>"
     },
     "without_feed_pig": {
         "recognition": "OCR",
@@ -657,7 +657,7 @@
         "next": [
             "check_club_mission_done"
         ],
-        "focus": "[color:DarkGoldenRod]大事不妙雷霆猪[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">大事不妙雷霆猪</font>"
     },
     "feed_pig": {
         "recognition": "OCR",
@@ -676,7 +676,7 @@
             "feed_pig_work",
             "feed_pig"
         ],
-        "focus": "[color:DeepSkyBlue]喂豚豚[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">喂豚豚</font>"
     },
     "feed_pig_work": {
         "recognition": "OCR",
@@ -693,13 +693,13 @@
         "on_error": [
             "feed_pig_not_found"
         ],
-        "focus": "[color:DeepSkyBlue]已进入喂豚豚[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已进入喂豚豚</font>"
     },
     "feed_pig_not_found": {
         "next": [
             "close_feed_pig"
         ],
-        "focus": "[color:DeepSkyBlue]无法找到喂豚豚按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">无法找到喂豚豚按钮</font>"
     },
     "weekly_feed_pig": {
         "max_hit": 5,
@@ -715,7 +715,7 @@
             "feed_pig_done",
             "close_feed_pig"
         ],
-        "focus": "[color:DeepSkyBlue]点击喂豚豚[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击喂豚豚</font>"
     },
     "feed_pig_done": {
         "recognition": "OCR",
@@ -727,7 +727,7 @@
         "next": [
             "close_feed_pig"
         ],
-        "focus": "[color:DeepSkyBlue]喂豚豚已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">喂豚豚已完成</font>"
     },
     "confirm_feed_pig": {
         "recognition": "OCR",
@@ -739,7 +739,7 @@
         "next": [
             "close_feed_pig"
         ],
-        "focus": "[color:DeepSkyBlue]确认喂豚豚[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认喂豚豚</font>"
     },
     "close_feed_pig": {
         "action": "ClickKey",
@@ -748,7 +748,7 @@
         "next": [
             "check_club_mission_done"
         ],
-        "focus": "[color:DeepSkyBlue]关闭喂豚豚[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭喂豚豚</font>"
     },
     "check_club_mission_done": {
         "next": [
@@ -791,13 +791,13 @@
             "gold_helper_done",
             "glod_helper_not_found"
         ],
-        "focus": "[color:DeepSkyBlue]上滑动去金币助手[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">上滑动去金币助手</font>"
     },
     "glod_helper_not_found": {
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "[color:red]没有找到金币助手任务[/color]"
+        "focus": "<font color=\"red\">没有找到金币助手任务</font>"
     },
     "gold_helper_undone": {
         "recognition": "TemplateMatch",
@@ -814,7 +814,7 @@
         "next": [
             "close_gold_helper"
         ],
-        "focus": "[color:DeepSkyBlue]金币助手未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">金币助手未完成</font>"
     },
     "gold_helper_wait": {
         "recognition": "TemplateMatch",
@@ -823,7 +823,7 @@
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "[color:DeepSkyBlue]可以领取金币助手活跃度奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">可以领取金币助手活跃度奖励</font>"
     },
     "gold_helper_done": {
         "recognition": "TemplateMatch",
@@ -832,7 +832,7 @@
         "next": [
             "swipe_for_club_submit"
         ],
-        "focus": "[color:DeepSkyBlue]金币助手已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">金币助手已完成</font>"
     },
     "close_gold_helper": {
         "action": "ClickKey",
@@ -843,7 +843,7 @@
             "swipe_for_club_submit",
             "[JumpBack]close_gold_helper"
         ],
-        "focus": "[color:DeepSkyBlue]关闭金币助手[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭金币助手</font>"
     },
     "swipe_for_club_submit": {
         "recognition": "OCR",
@@ -895,7 +895,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DarkGoldenRod]这里已经空了,可能是系统繁忙,退出请报社[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">这里已经空了,可能是系统繁忙,退出请报社</font>"
     },
     "check_club_all_submit": {
         "max_hit": 5,
@@ -919,7 +919,7 @@
         "on_error": [
             "try_esc"
         ],
-        "focus": "[color:DeepSkyBlue]检测任务是否已经全部提交[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测任务是否已经全部提交</font>"
     },
     "club_submit": {
         "recognition": "TemplateMatch",
@@ -953,7 +953,7 @@
         "next": [
             "naruto_club_back_post"
         ],
-        "focus": "[color:DarkGoldenRod]土豆[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">土豆</font>"
     },
     "naruto_club_back_post": {
         "max_hit": 9,
@@ -968,14 +968,14 @@
             "benefit_station",
             "naruto_club_back_post"
         ],
-        "focus": "[color:DeepSkyBlue]退回话题[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">退回话题</font>"
     },
     "start_qq": {
         "pre_delay": 1000,
         "action": "StartApp",
         "package": "com.tencent.mobileqq",
         "post_delay": 1000,
-        "focus": "[color:DeepSkyBlue]打开qq[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开qq</font>"
     },
     "club_first_award_done": {
         "recognition": "TemplateMatch",
@@ -993,7 +993,7 @@
             "club_second_award_done",
             "[JumpBack]club_second_award"
         ],
-        "focus": "[color:DeepSkyBlue]第一个奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第一个奖励已领取</font>"
     },
     "club_first_award": {
         "max_hit": 3,
@@ -1017,7 +1017,7 @@
             "club_first_award"
         ],
         "on_error": "naruto_club_in_loop_wheel",
-        "focus": "[color:DeepSkyBlue]领取第一个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取第一个奖励</font>"
     },
     "club_first_award_on_error": {
         "max_hit": 3,
@@ -1038,7 +1038,7 @@
             "confirm_club_first_award"
         ],
         "on_error": "naruto_club_in_loop_wheel",
-        "focus": "[color:DeepSkyBlue]第二次领取第一个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第二次领取第一个奖励</font>"
     },
     "confirm_club_first_award": {
         "recognition": "OCR",
@@ -1062,7 +1062,7 @@
         "on_error": [
             "naruto_club_in_loop_wheel"
         ],
-        "focus": "[color:DeepSkyBlue]确认领取第一个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取第一个奖励</font>"
     },
     "roger_club_first_award": {
         "recognition": "OCR",
@@ -1090,7 +1090,7 @@
         "next": [
             "naruto_club_back_post"
         ],
-        "focus": "[color:DarkGoldenRod]意志坚定[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">意志坚定</font>"
     },
     "club_second_award": {
         "recognition": "TemplateMatch",
@@ -1110,7 +1110,7 @@
             "club_second_award_done"
         ],
         "on_error": "award_kale",
-        "focus": "[color:DeepSkyBlue]领取第二个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取第二个奖励</font>"
     },
     "confirm_club_second_award": {
         "recognition": "OCR",
@@ -1131,7 +1131,7 @@
             "confirm_club_second_award",
             "club_second_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]确认领取第二个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取第二个奖励</font>"
     },
     "roger_club_second_award": {
         "recognition": "OCR",
@@ -1166,14 +1166,14 @@
         "on_error": [
             "no_third_award"
         ],
-        "focus": "[color:DeepSkyBlue]第二个奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第二个奖励已领取</font>"
     },
     "no_third_award": {
         "recognition": "DirectHit",
         "next": [
             "close_naruto_club"
         ],
-        "focus": "[color:red]无法领取第三奖励[/color]"
+        "focus": "<font color=\"red\">无法领取第三奖励</font>"
     },
     "club_third_award": {
         "max_hit": 3,
@@ -1194,7 +1194,7 @@
             "[JumpBack]club_third_award",
             "club_third_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]领取第三个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取第三个奖励</font>"
     },
     "confirm_club_third_award": {
         "recognition": "OCR",
@@ -1214,7 +1214,7 @@
             "confirm_club_third_award",
             "club_third_award_done"
         ],
-        "focus": "[color:DeepSkyBlue]确认领取第三个奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取第三个奖励</font>"
     },
     "roger_club_third_award": {
         "recognition": "OCR",
@@ -1248,7 +1248,7 @@
         "next": [
             "close_naruto_club"
         ],
-        "focus": "[color:DeepSkyBlue]第三个奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">第三个奖励已领取</font>"
     },
     "close_naruto_club": {
         "recognition": "TemplateMatch",
@@ -1263,7 +1263,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]关闭情报社[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
     },
     "shut_qq": {
         "pre_delay": 0,
@@ -1285,7 +1285,7 @@
     },
     "award_kale": {
         "action": "StopTask",
-        "focus": "[color:DarkGoldenRod]当前操作超时，疑似遇到真投入[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">当前操作超时，疑似遇到真投入</font>"
     },
     "try_esc": {
         "max_hit": 1,

--- a/assets/resource/base/pipeline/Nindao_clash.json
+++ b/assets/resource/base/pipeline/Nindao_clash.json
@@ -7,7 +7,7 @@
             "nindao_clash_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍道交锋任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍道交锋任务</font>"
     },
     "nindao_clash_entry": {
         "recognition": "TemplateMatch",
@@ -34,7 +34,7 @@
             "nindao_clash_not_in_main_screen",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "nindao_clash_not_in_main_screen": {
         "pre_delay": 0,
@@ -62,7 +62,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往忍道交锋[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往忍道交锋</font>"
     },
     "find_nindao_clash": {
         "recognition": "OCR",
@@ -91,7 +91,7 @@
             "select_nindao_clash",
             "find_nindao_clash"
         ],
-        "focus": "[color:DeepSkyBlue]找到忍界交锋[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到忍界交锋</font>"
     },
     "select_nindao_clash": {
         "recognition": "Or",
@@ -125,7 +125,7 @@
             "nindao_clash_undone",
             "nindao_clash_without_red_point"
         ],
-        "focus": "[color:DeepSkyBlue]选中忍界交锋[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中忍界交锋</font>"
     },
     "nindao_clash_undone": {
         "recognition": "TemplateMatch",
@@ -305,7 +305,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]忍道交锋到达尽头[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍道交锋到达尽头</font>"
     },
     "nindao_clash_low": {
         "recognition": "TemplateMatch",
@@ -357,7 +357,7 @@
             "nindao_clash_sweep",
             "nindao_clash_go"
         ],
-        "focus": "[color:DeepSkyBlue]发现四倍金箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">发现四倍金箱</font>"
     },
     "nindao_clash_gold_8": {
         "recognition": "TemplateMatch",
@@ -375,7 +375,7 @@
             "nindao_clash_sweep",
             "nindao_clash_go"
         ],
-        "focus": "[color:DeepSkyBlue]发现八倍金箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">发现八倍金箱</font>"
     },
     "nindao_clash_refresh": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Nindao_clash.json
+++ b/assets/resource/base/pipeline/Nindao_clash.json
@@ -7,7 +7,9 @@
             "nindao_clash_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍道交锋任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍道交锋任务</font>"
+        }
     },
     "nindao_clash_entry": {
         "recognition": "TemplateMatch",
@@ -34,7 +36,9 @@
             "nindao_clash_not_in_main_screen",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "nindao_clash_not_in_main_screen": {
         "pre_delay": 0,
@@ -62,7 +66,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往忍道交锋</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往忍道交锋</font>"
+        }
     },
     "find_nindao_clash": {
         "recognition": "OCR",
@@ -91,7 +97,9 @@
             "select_nindao_clash",
             "find_nindao_clash"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到忍界交锋</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到忍界交锋</font>"
+        }
     },
     "select_nindao_clash": {
         "recognition": "Or",
@@ -125,7 +133,9 @@
             "nindao_clash_undone",
             "nindao_clash_without_red_point"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中忍界交锋</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中忍界交锋</font>"
+        }
     },
     "nindao_clash_undone": {
         "recognition": "TemplateMatch",
@@ -305,7 +315,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍道交锋到达尽头</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍道交锋到达尽头</font>"
+        }
     },
     "nindao_clash_low": {
         "recognition": "TemplateMatch",
@@ -357,7 +369,9 @@
             "nindao_clash_sweep",
             "nindao_clash_go"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">发现四倍金箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">发现四倍金箱</font>"
+        }
     },
     "nindao_clash_gold_8": {
         "recognition": "TemplateMatch",
@@ -375,7 +389,9 @@
             "nindao_clash_sweep",
             "nindao_clash_go"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">发现八倍金箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">发现八倍金箱</font>"
+        }
     },
     "nindao_clash_refresh": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Ninja_book.json
+++ b/assets/resource/base/pipeline/Ninja_book.json
@@ -5,7 +5,7 @@
         "next": [
             "ninja_book_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍法帖任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖任务</font>"
     },
     "ninja_book_entry": {
         "pre_delay": 0,
@@ -31,7 +31,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖已完成</font>"
     },
     "ninja_book_undone": {
         "recognition": "TemplateMatch",
@@ -54,7 +54,7 @@
             "[JumpBack]hit_to_enter_ninja_book_x",
             "[JumpBack]ninja_book_skip"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖未完成</font>"
     },
     "ninja_book_skip": {
         "recognition": "OCR",
@@ -85,7 +85,7 @@
             "位置"
         ],
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]忍法帖忍者展示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
     },
     "hit_to_enter_ninja_book_x": {
         "recognition": "TemplateMatch",
@@ -99,7 +99,7 @@
         "green_mask": true,
         "threshold": 0.68,
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]忍法帖忍者展示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
     },
     "ninja_book_share_to_qq": {
         "recognition": "TemplateMatch",
@@ -120,7 +120,7 @@
             "ninja_book_share_back_to_natuto",
             "close_ninja_book_qq_share"
         ],
-        "focus": "[color:DeepSkyBlue]qq分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">qq分享</font>"
     },
     "close_ninja_book_qq_share": {
         "pre_delay": 1000,
@@ -131,7 +131,7 @@
             "ninja_book_quit_x",
             "ninja_book_close_share_top_bar"
         ],
-        "focus": "[color:DeepSkyBlue]关闭qq分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭qq分享</font>"
     },
     "ninja_book_share_to_wechat": {
         "recognition": "TemplateMatch",
@@ -152,7 +152,7 @@
             "ninja_book_share_back_to_natuto",
             "close_ninja_book_wechat_share"
         ],
-        "focus": "[color:DeepSkyBlue]微信分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">微信分享</font>"
     },
     "close_ninja_book_wechat_share": {
         "pre_delay": 1000,
@@ -168,7 +168,7 @@
             "ninja_book_close_share_top_bar",
             "ninja_book_share_without_x"
         ],
-        "focus": "[color:DeepSkyBlue]关闭分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭分享</font>"
     },
     "ninja_book_close_share_top_bar": {
         "max_hit": 5,
@@ -198,7 +198,7 @@
             "ninja_book_close_share_top_bar",
             "ninja_book_share_without_x"
         ],
-        "focus": "[color:DeepSkyBlue]关闭顶部栏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
     },
     "ninja_book_quit_x": {
         "recognition": "TemplateMatch",
@@ -240,7 +240,7 @@
         "next": [
             "ninja_book_cancel_quit"
         ],
-        "focus": "[color:DarkGoldenRod]没有退出的地方[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">没有退出的地方</font>"
     },
     "ninja_book_cancel_quit": {
         "recognition": "TemplateMatch",
@@ -330,7 +330,7 @@
         "next": [
             "ninja_book_mission_award"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖任务未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖任务未完成</font>"
     },
     "ninja_book_mission_award": {
         "pre_delay": 0,
@@ -370,7 +370,7 @@
             "ninja_book_without_level_up_page",
             "close_ninja_book_level_up_page"
         ],
-        "focus": "[color:DeepSkyBlue]关闭升级界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭升级界面</font>"
     },
     "ninja_book_without_level_up_page": {
         "recognition": "OCR",
@@ -409,7 +409,7 @@
             "ninja_book_liveness_done",
             "[JumpBack]close_ninja_book_liveness_detail"
         ],
-        "focus": "[color:DeepSkyBlue]检查有没有任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检查有没有任务奖励</font>"
     },
     "get_ninja_book_mission_award": {
         "recognition": "OCR",
@@ -426,7 +426,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]领取忍法帖任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取忍法帖任务奖励</font>"
     },
     "get_ninja_book_mission_award_one_key": {
         "recognition": "OCR",
@@ -443,7 +443,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]一键领取忍法帖任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">一键领取忍法帖任务奖励</font>"
     },
     "ninja_book_liveness_done": {
         "recognition": "TemplateMatch",
@@ -465,7 +465,7 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖活跃度奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励已领取</font>"
     },
     "ninja_book_liveness_undone": {
         "recognition": "TemplateMatch",
@@ -485,7 +485,7 @@
             "check_selected_ninja_book_liveness",
             "[JumpBack]ninja_book_liveness_undone"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖活跃度奖励未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励未领取</font>"
     },
     "check_selected_ninja_book_liveness": {
         "recognition": "TemplateMatch",
@@ -510,7 +510,7 @@
             "[JumpBack]close_ninja_book_level_up_page_when_liveness",
             "[JumpBack]close_ninja_book_liveness_detail"
         ],
-        "focus": "[color:DeepSkyBlue]确认已经选中活跃度奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认已经选中活跃度奖励</font>"
     },
     "close_ninja_book_liveness_detail": {
         "recognition": "TemplateMatch",
@@ -531,7 +531,7 @@
         ],
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]关闭活跃度详情[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭活跃度详情</font>"
     },
     "ninja_book_liveness_award": {
         "recognition": "TemplateMatch",
@@ -549,7 +549,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 3000,
-        "focus": "[color:DeepSkyBlue]领取活跃度奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取活跃度奖励</font>"
     },
     "check_no_ninja_book_liveness_award": {
         "recognition": "TemplateMatch",
@@ -574,7 +574,7 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]没有可领取的活跃度奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">没有可领取的活跃度奖励</font>"
     },
     "treasure_box_undone": {
         "recognition": "OCR",
@@ -595,7 +595,7 @@
             "treasure_box_in_treasure_box",
             "[JumpBack]treasure_box_undone"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣未领取</font>"
     },
     "treasure_box_in_treasure_box": {
         "recognition": "TemplateMatch",
@@ -634,7 +634,7 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣可抽奖[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣可抽奖</font>"
     },
     "treasure_box_access_method_undone": {
         "recognition": "TemplateMatch",
@@ -653,7 +653,7 @@
             "ninja_book_check_in_treasure_box_access_method",
             "[JumpBack]treasure_box_access_method_undone"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣可领取或挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣可领取或挑战</font>"
     },
     "ninja_book_check_in_treasure_box_access_method": {
         "recognition": "OCR",
@@ -674,7 +674,7 @@
             "check_no_treasure_box_award",
             "[JumpBack]get_treasure_box_award"
         ],
-        "focus": "[color:DeepSkyBlue]进入宝匣获取方式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入宝匣获取方式</font>"
     },
     "get_treasure_box_award": {
         "recognition": "TemplateMatch",
@@ -705,7 +705,7 @@
             "get_treasure_box_award",
             "check_no_treasure_box_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取宝匣奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取宝匣奖励</font>"
     },
     "check_no_treasure_box_award": {
         "recognition": "TemplateMatch",
@@ -725,7 +725,7 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]检查还有没有宝匣奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检查还有没有宝匣奖励</font>"
     },
     "get_treasure_box_award_one_key": {
         "recognition": "TemplateMatch",
@@ -747,7 +747,7 @@
             "get_treasure_box_award_without_one_key",
             "[JumpBack]get_treasure_box_award_one_key"
         ],
-        "focus": "[color:DeepSkyBlue]一键领取宝匣奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">一键领取宝匣奖励</font>"
     },
     "get_treasure_box_award_without_one_key": {
         "recognition": "TemplateMatch",
@@ -783,7 +783,7 @@
             "treasure_box_celebrate",
             "[JumpBack]treasure_box_challenge"
         ],
-        "focus": "[color:DeepSkyBlue]前往宝匣挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
     },
     "treasure_box_celebrate": {
         "recognition": "OCR",
@@ -805,7 +805,7 @@
             "treasure_box_without_celebrate",
             "treasure_box_celebrate"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣扫荡完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
     },
     "treasure_box_without_celebrate": {
         "recognition": "OCR",
@@ -827,7 +827,7 @@
             "ninja_book_award_undone",
             "ninja_book_award_selected"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣扫荡完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
     },
     "treasure_box_sweep": {
         "recognition": "OCR",
@@ -855,7 +855,7 @@
             "ninja_book_award_selected",
             "[JumpBack]treasure_box_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]前往宝匣挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
     },
     "treasure_box_challenge_confirm_ninja": {
         "recognition": "OCR",
@@ -876,7 +876,7 @@
             "treasure_box_challenge_without_confirm_ninja",
             "treasure_box_challenge_confirm_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣挑战确认忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣挑战确认忍者</font>"
     },
     "treasure_box_challenge_without_confirm_ninja": {
         "recognition": "OCR",
@@ -909,7 +909,7 @@
             "资源加载"
         ],
         "post_delay": 1000,
-        "focus": "[color:DeepSkyBlue]宝匣挑战加载中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣挑战加载中</font>"
     },
     "treasure_box_challenge_in_fight": {
         "recognition": "TemplateMatch",
@@ -949,7 +949,7 @@
             "treasure_box_challenge_quit",
             "treasure_box_challenge_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣不在战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣不在战斗</font>"
     },
     "treasure_box_challenge_quit": {
         "recognition": "OCR",
@@ -971,7 +971,7 @@
             "treasure_box_challenge_out_quit",
             "treasure_box_challenge_quit"
         ],
-        "focus": "[color:DeepSkyBlue]宝匣退出战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">宝匣退出战斗</font>"
     },
     "treasure_box_challenge_out_quit": {
         "recognition": "OCR",
@@ -1015,7 +1015,7 @@
         ],
         "post_wait_freezes": 600,
         "post_delay": 0,
-        "focus": "[color:darkgray]关闭领取活跃度奖励时的升级界面[/color]"
+        "focus": "<font color=\"darkgray\">关闭领取活跃度奖励时的升级界面</font>"
     },
     "ninja_book_leaderboard": {
         "recognition": "TemplateMatch",
@@ -1035,7 +1035,7 @@
             "ninja_book_leaderboard_like_done",
             "[JumpBack]ninja_book_leaderboard"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍法帖排行榜界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面</font>"
     },
     "ninja_book_leaderboard_like_done": {
         "recognition": "TemplateMatch",
@@ -1051,7 +1051,7 @@
         "next": [
             "ninja_book_share"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍法帖排行榜界面已点赞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面已点赞</font>"
     },
     "ninja_book_leaderboard_like_undone": {
         "recognition": "TemplateMatch",
@@ -1067,7 +1067,7 @@
             "ninja_book_share",
             "[JumpBack]close_ninja_book_level_up_page_when_like"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖排行榜点赞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖排行榜点赞</font>"
     },
     "close_ninja_book_level_up_page_when_like": {
         "recognition": "OCR",
@@ -1090,7 +1090,7 @@
         ],
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]关闭出现在排行榜点赞后的升级界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭出现在排行榜点赞后的升级界面</font>"
     },
     "ninja_book_share": {
         "recognition": "OCR",
@@ -1112,13 +1112,13 @@
             "ninja_book_share_to_wechat",
             "[JumpBack]ninja_book_share"
         ],
-        "focus": "[color:darkgray]进入分享页面[/color]"
+        "focus": "<font color=\"darkgray\">进入分享页面</font>"
     },
     "ninja_book_is_android_then_no_share": {
         "recognition": "Custom",
         "custom_recognition": "CheckIsAndroid",
         "next": "close_ninja_book_leaderboard",
-        "focus": "[color:darkorange]不支持在安卓上进行分享，请使用模拟器！[/color]"
+        "focus": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
     },
     "close_ninja_book_leaderboard": {
         "recognition": "TemplateMatch",
@@ -1138,7 +1138,7 @@
             "ninja_book_mission_done",
             "[JumpBack]close_ninja_book_leaderboard"
         ],
-        "focus": "[color:DeepSkyBlue]关闭忍法帖排行榜[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭忍法帖排行榜</font>"
     },
     "ninja_book_award_undone": {
         "max_hit": 4,
@@ -1161,7 +1161,7 @@
             "[JumpBack]ninja_book_award_undone",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖奖励未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
     },
     "ninja_book_award_selected": {
         "max_hit": 3,
@@ -1184,7 +1184,7 @@
             "ninja_book_award_swip_to_left",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]忍法帖奖励未领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
     },
     "ninja_book_award_swip_to_left": {
         "action": "Swipe",
@@ -1207,7 +1207,7 @@
             "[JumpBack]get_ninja_book_award",
             "[JumpBack]ninja_book_award_swipe_to_right"
         ],
-        "focus": "[color:DeepSkyBlue]左滑动到忍法帖奖励前部[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">左滑动到忍法帖奖励前部</font>"
     },
     "top_level_award": {
         "recognition": "OCR",
@@ -1223,7 +1223,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]滑动到忍法帖165级[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">滑动到忍法帖165级</font>"
     },
     "ninja_book_award_swipe_to_right": {
         "recognition": "TemplateMatch",
@@ -1252,7 +1252,7 @@
             86
         ],
         "duration": 500,
-        "focus": "[color:DeepSkyBlue]右滑领取忍法帖奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">右滑领取忍法帖奖励</font>"
     },
     "check_no_ninja_book_award_red_point": {
         "recognition": "TemplateMatch",
@@ -1274,7 +1274,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]检查没有忍法帖奖励红点[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检查没有忍法帖奖励红点</font>"
     },
     "get_ninja_book_award": {
         "recognition": "TemplateMatch",
@@ -1304,7 +1304,7 @@
         "next": [
             "confirm_ninja_book_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取忍法帖奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取忍法帖奖励</font>"
     },
     "confirm_ninja_book_award": {
         "recognition": "TemplateMatch",
@@ -1317,7 +1317,7 @@
         "template": "Ninja_book/get_award.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "[color:DeepSkyBlue]确认领取忍法帖奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认领取忍法帖奖励</font>"
     },
     "treasure_box_click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Ninja_book.json
+++ b/assets/resource/base/pipeline/Ninja_book.json
@@ -5,7 +5,9 @@
         "next": [
             "ninja_book_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍法帖任务</font>"
+        }
     },
     "ninja_book_entry": {
         "pre_delay": 0,
@@ -31,7 +33,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖已完成</font>"
+        }
     },
     "ninja_book_undone": {
         "recognition": "TemplateMatch",
@@ -54,7 +58,9 @@
             "[JumpBack]hit_to_enter_ninja_book_x",
             "[JumpBack]ninja_book_skip"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖未完成</font>"
+        }
     },
     "ninja_book_skip": {
         "recognition": "OCR",
@@ -85,7 +91,9 @@
             "位置"
         ],
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
+        }
     },
     "hit_to_enter_ninja_book_x": {
         "recognition": "TemplateMatch",
@@ -99,7 +107,9 @@
         "green_mask": true,
         "threshold": 0.68,
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖忍者展示</font>"
+        }
     },
     "ninja_book_share_to_qq": {
         "recognition": "TemplateMatch",
@@ -120,7 +130,9 @@
             "ninja_book_share_back_to_natuto",
             "close_ninja_book_qq_share"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">qq分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">qq分享</font>"
+        }
     },
     "close_ninja_book_qq_share": {
         "pre_delay": 1000,
@@ -131,7 +143,9 @@
             "ninja_book_quit_x",
             "ninja_book_close_share_top_bar"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭qq分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭qq分享</font>"
+        }
     },
     "ninja_book_share_to_wechat": {
         "recognition": "TemplateMatch",
@@ -152,7 +166,9 @@
             "ninja_book_share_back_to_natuto",
             "close_ninja_book_wechat_share"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">微信分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">微信分享</font>"
+        }
     },
     "close_ninja_book_wechat_share": {
         "pre_delay": 1000,
@@ -168,7 +184,9 @@
             "ninja_book_close_share_top_bar",
             "ninja_book_share_without_x"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭分享</font>"
+        }
     },
     "ninja_book_close_share_top_bar": {
         "max_hit": 5,
@@ -198,7 +216,9 @@
             "ninja_book_close_share_top_bar",
             "ninja_book_share_without_x"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
+        }
     },
     "ninja_book_quit_x": {
         "recognition": "TemplateMatch",
@@ -240,7 +260,9 @@
         "next": [
             "ninja_book_cancel_quit"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">没有退出的地方</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">没有退出的地方</font>"
+        }
     },
     "ninja_book_cancel_quit": {
         "recognition": "TemplateMatch",
@@ -330,7 +352,9 @@
         "next": [
             "ninja_book_mission_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖任务未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖任务未完成</font>"
+        }
     },
     "ninja_book_mission_award": {
         "pre_delay": 0,
@@ -370,7 +394,9 @@
             "ninja_book_without_level_up_page",
             "close_ninja_book_level_up_page"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭升级界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭升级界面</font>"
+        }
     },
     "ninja_book_without_level_up_page": {
         "recognition": "OCR",
@@ -409,7 +435,9 @@
             "ninja_book_liveness_done",
             "[JumpBack]close_ninja_book_liveness_detail"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检查有没有任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检查有没有任务奖励</font>"
+        }
     },
     "get_ninja_book_mission_award": {
         "recognition": "OCR",
@@ -426,7 +454,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">领取忍法帖任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取忍法帖任务奖励</font>"
+        }
     },
     "get_ninja_book_mission_award_one_key": {
         "recognition": "OCR",
@@ -443,7 +473,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">一键领取忍法帖任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">一键领取忍法帖任务奖励</font>"
+        }
     },
     "ninja_book_liveness_done": {
         "recognition": "TemplateMatch",
@@ -465,7 +497,9 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励已领取</font>"
+        }
     },
     "ninja_book_liveness_undone": {
         "recognition": "TemplateMatch",
@@ -485,7 +519,9 @@
             "check_selected_ninja_book_liveness",
             "[JumpBack]ninja_book_liveness_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖活跃度奖励未领取</font>"
+        }
     },
     "check_selected_ninja_book_liveness": {
         "recognition": "TemplateMatch",
@@ -510,7 +546,9 @@
             "[JumpBack]close_ninja_book_level_up_page_when_liveness",
             "[JumpBack]close_ninja_book_liveness_detail"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认已经选中活跃度奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认已经选中活跃度奖励</font>"
+        }
     },
     "close_ninja_book_liveness_detail": {
         "recognition": "TemplateMatch",
@@ -531,7 +569,9 @@
         ],
         "post_wait_freezes": 500,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">关闭活跃度详情</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭活跃度详情</font>"
+        }
     },
     "ninja_book_liveness_award": {
         "recognition": "TemplateMatch",
@@ -549,7 +589,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 3000,
-        "focus": "<font color=\"DeepSkyBlue\">领取活跃度奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取活跃度奖励</font>"
+        }
     },
     "check_no_ninja_book_liveness_award": {
         "recognition": "TemplateMatch",
@@ -574,7 +616,9 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">没有可领取的活跃度奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">没有可领取的活跃度奖励</font>"
+        }
     },
     "treasure_box_undone": {
         "recognition": "OCR",
@@ -595,7 +639,9 @@
             "treasure_box_in_treasure_box",
             "[JumpBack]treasure_box_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣未领取</font>"
+        }
     },
     "treasure_box_in_treasure_box": {
         "recognition": "TemplateMatch",
@@ -634,7 +680,9 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣可抽奖</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣可抽奖</font>"
+        }
     },
     "treasure_box_access_method_undone": {
         "recognition": "TemplateMatch",
@@ -653,7 +701,9 @@
             "ninja_book_check_in_treasure_box_access_method",
             "[JumpBack]treasure_box_access_method_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣可领取或挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣可领取或挑战</font>"
+        }
     },
     "ninja_book_check_in_treasure_box_access_method": {
         "recognition": "OCR",
@@ -674,7 +724,9 @@
             "check_no_treasure_box_award",
             "[JumpBack]get_treasure_box_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入宝匣获取方式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入宝匣获取方式</font>"
+        }
     },
     "get_treasure_box_award": {
         "recognition": "TemplateMatch",
@@ -705,7 +757,9 @@
             "get_treasure_box_award",
             "check_no_treasure_box_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取宝匣奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取宝匣奖励</font>"
+        }
     },
     "check_no_treasure_box_award": {
         "recognition": "TemplateMatch",
@@ -725,7 +779,9 @@
             "ninja_book_award_selected",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检查还有没有宝匣奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检查还有没有宝匣奖励</font>"
+        }
     },
     "get_treasure_box_award_one_key": {
         "recognition": "TemplateMatch",
@@ -747,7 +803,9 @@
             "get_treasure_box_award_without_one_key",
             "[JumpBack]get_treasure_box_award_one_key"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">一键领取宝匣奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">一键领取宝匣奖励</font>"
+        }
     },
     "get_treasure_box_award_without_one_key": {
         "recognition": "TemplateMatch",
@@ -783,7 +841,9 @@
             "treasure_box_celebrate",
             "[JumpBack]treasure_box_challenge"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
+        }
     },
     "treasure_box_celebrate": {
         "recognition": "OCR",
@@ -805,7 +865,9 @@
             "treasure_box_without_celebrate",
             "treasure_box_celebrate"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
+        }
     },
     "treasure_box_without_celebrate": {
         "recognition": "OCR",
@@ -827,7 +889,9 @@
             "ninja_book_award_undone",
             "ninja_book_award_selected"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣扫荡完成</font>"
+        }
     },
     "treasure_box_sweep": {
         "recognition": "OCR",
@@ -855,7 +919,9 @@
             "ninja_book_award_selected",
             "[JumpBack]treasure_box_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往宝匣挑战</font>"
+        }
     },
     "treasure_box_challenge_confirm_ninja": {
         "recognition": "OCR",
@@ -876,7 +942,9 @@
             "treasure_box_challenge_without_confirm_ninja",
             "treasure_box_challenge_confirm_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣挑战确认忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣挑战确认忍者</font>"
+        }
     },
     "treasure_box_challenge_without_confirm_ninja": {
         "recognition": "OCR",
@@ -909,7 +977,9 @@
             "资源加载"
         ],
         "post_delay": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">宝匣挑战加载中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣挑战加载中</font>"
+        }
     },
     "treasure_box_challenge_in_fight": {
         "recognition": "TemplateMatch",
@@ -949,7 +1019,9 @@
             "treasure_box_challenge_quit",
             "treasure_box_challenge_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣不在战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣不在战斗</font>"
+        }
     },
     "treasure_box_challenge_quit": {
         "recognition": "OCR",
@@ -971,7 +1043,9 @@
             "treasure_box_challenge_out_quit",
             "treasure_box_challenge_quit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">宝匣退出战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">宝匣退出战斗</font>"
+        }
     },
     "treasure_box_challenge_out_quit": {
         "recognition": "OCR",
@@ -1015,7 +1089,9 @@
         ],
         "post_wait_freezes": 600,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">关闭领取活跃度奖励时的升级界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">关闭领取活跃度奖励时的升级界面</font>"
+        }
     },
     "ninja_book_leaderboard": {
         "recognition": "TemplateMatch",
@@ -1035,7 +1111,9 @@
             "ninja_book_leaderboard_like_done",
             "[JumpBack]ninja_book_leaderboard"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面</font>"
+        }
     },
     "ninja_book_leaderboard_like_done": {
         "recognition": "TemplateMatch",
@@ -1051,7 +1129,9 @@
         "next": [
             "ninja_book_share"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面已点赞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍法帖排行榜界面已点赞</font>"
+        }
     },
     "ninja_book_leaderboard_like_undone": {
         "recognition": "TemplateMatch",
@@ -1067,7 +1147,9 @@
             "ninja_book_share",
             "[JumpBack]close_ninja_book_level_up_page_when_like"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖排行榜点赞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖排行榜点赞</font>"
+        }
     },
     "close_ninja_book_level_up_page_when_like": {
         "recognition": "OCR",
@@ -1090,7 +1172,9 @@
         ],
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">关闭出现在排行榜点赞后的升级界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭出现在排行榜点赞后的升级界面</font>"
+        }
     },
     "ninja_book_share": {
         "recognition": "OCR",
@@ -1112,13 +1196,17 @@
             "ninja_book_share_to_wechat",
             "[JumpBack]ninja_book_share"
         ],
-        "focus": "<font color=\"darkgray\">进入分享页面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">进入分享页面</font>"
+        }
     },
     "ninja_book_is_android_then_no_share": {
         "recognition": "Custom",
         "custom_recognition": "CheckIsAndroid",
         "next": "close_ninja_book_leaderboard",
-        "focus": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
+        }
     },
     "close_ninja_book_leaderboard": {
         "recognition": "TemplateMatch",
@@ -1138,7 +1226,9 @@
             "ninja_book_mission_done",
             "[JumpBack]close_ninja_book_leaderboard"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭忍法帖排行榜</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭忍法帖排行榜</font>"
+        }
     },
     "ninja_book_award_undone": {
         "max_hit": 4,
@@ -1161,7 +1251,9 @@
             "[JumpBack]ninja_book_award_undone",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
+        }
     },
     "ninja_book_award_selected": {
         "max_hit": 3,
@@ -1184,7 +1276,9 @@
             "ninja_book_award_swip_to_left",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍法帖奖励未领取</font>"
+        }
     },
     "ninja_book_award_swip_to_left": {
         "action": "Swipe",
@@ -1207,7 +1301,9 @@
             "[JumpBack]get_ninja_book_award",
             "[JumpBack]ninja_book_award_swipe_to_right"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">左滑动到忍法帖奖励前部</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">左滑动到忍法帖奖励前部</font>"
+        }
     },
     "top_level_award": {
         "recognition": "OCR",
@@ -1223,7 +1319,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">滑动到忍法帖165级</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">滑动到忍法帖165级</font>"
+        }
     },
     "ninja_book_award_swipe_to_right": {
         "recognition": "TemplateMatch",
@@ -1252,7 +1350,9 @@
             86
         ],
         "duration": 500,
-        "focus": "<font color=\"DeepSkyBlue\">右滑领取忍法帖奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">右滑领取忍法帖奖励</font>"
+        }
     },
     "check_no_ninja_book_award_red_point": {
         "recognition": "TemplateMatch",
@@ -1274,7 +1374,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检查没有忍法帖奖励红点</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检查没有忍法帖奖励红点</font>"
+        }
     },
     "get_ninja_book_award": {
         "recognition": "TemplateMatch",
@@ -1304,7 +1406,9 @@
         "next": [
             "confirm_ninja_book_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取忍法帖奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取忍法帖奖励</font>"
+        }
     },
     "confirm_ninja_book_award": {
         "recognition": "TemplateMatch",
@@ -1317,7 +1421,9 @@
         "template": "Ninja_book/get_award.png",
         "action": "Click",
         "post_wait_freezes": 200,
-        "focus": "<font color=\"DeepSkyBlue\">确认领取忍法帖奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认领取忍法帖奖励</font>"
+        }
     },
     "treasure_box_click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Point_race.json
+++ b/assets/resource/base/pipeline/Point_race.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入积分赛任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入积分赛任务</font>"
+        }
     },
     "go_into_point_race": {
         "recognition": {
@@ -33,7 +35,9 @@
             "point_race_challenge_enter",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入积分赛</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入积分赛</font>"
+        }
     },
     "point_race_challenge_enter": {
         "recognition": "TemplateMatch",
@@ -61,7 +65,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">积分赛挑战次数已用完</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">积分赛挑战次数已用完</font>"
+        }
     },
     "wait_for_select_opponent": {
         "recognition": "TemplateMatch",
@@ -78,7 +84,9 @@
             "point_race_challenge",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始选择对手</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始选择对手</font>"
+        }
     },
     "point_race_cross_server": {
         "recognition": "TemplateMatch",
@@ -157,7 +165,9 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入积分赛战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入积分赛战斗</font>"
+        }
     },
     "point_race_loading": {
         "recognition": "OCR",
@@ -197,7 +207,9 @@
             "point_race_challenge_finished",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">鸣佐</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">鸣佐</font>"
+        }
     },
     "point_race_quit": {
         "recognition": "TemplateMatch",
@@ -207,7 +219,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不进行挑战直接退出</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不进行挑战直接退出</font>"
+        }
     },
     "point_race_skip": {
         "recognition": "OCR",
@@ -278,7 +292,9 @@
             "point_race_challenge_enter",
             "point_race_direct_hit_quit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">积分赛失败,再战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">积分赛失败,再战</font>"
+        }
     },
     "point_race_get_challenge_button": {
         "recognition": "OCR",
@@ -311,7 +327,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "point_race_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -337,6 +355,8 @@
             "point_race_challenge_enter",
             "point_race_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">积分赛未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">积分赛未完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Point_race.json
+++ b/assets/resource/base/pipeline/Point_race.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入积分赛任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入积分赛任务</font>"
     },
     "go_into_point_race": {
         "recognition": {
@@ -33,7 +33,7 @@
             "point_race_challenge_enter",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "[color:DeepSkyBlue]进入积分赛[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入积分赛</font>"
     },
     "point_race_challenge_enter": {
         "recognition": "TemplateMatch",
@@ -61,7 +61,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]积分赛挑战次数已用完[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">积分赛挑战次数已用完</font>"
     },
     "wait_for_select_opponent": {
         "recognition": "TemplateMatch",
@@ -78,7 +78,7 @@
             "point_race_challenge",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]开始选择对手[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始选择对手</font>"
     },
     "point_race_cross_server": {
         "recognition": "TemplateMatch",
@@ -157,7 +157,7 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入积分赛战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入积分赛战斗</font>"
     },
     "point_race_loading": {
         "recognition": "OCR",
@@ -197,7 +197,7 @@
             "point_race_challenge_finished",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DarkGoldenRod]鸣佐[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">鸣佐</font>"
     },
     "point_race_quit": {
         "recognition": "TemplateMatch",
@@ -207,7 +207,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]不进行挑战直接退出[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不进行挑战直接退出</font>"
     },
     "point_race_skip": {
         "recognition": "OCR",
@@ -278,7 +278,7 @@
             "point_race_challenge_enter",
             "point_race_direct_hit_quit"
         ],
-        "focus": "[color:DeepSkyBlue]积分赛失败,再战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">积分赛失败,再战</font>"
     },
     "point_race_get_challenge_button": {
         "recognition": "OCR",
@@ -311,7 +311,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "point_race_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -337,6 +337,6 @@
             "point_race_challenge_enter",
             "point_race_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]积分赛未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">积分赛未完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Rebel_ninja.json
+++ b/assets/resource/base/pipeline/Rebel_ninja.json
@@ -11,7 +11,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入叛忍来袭任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入叛忍来袭任务</font>"
+        }
     },
     "goto_rebel_ninja_by_guide": {
         "recognition": "Custom",
@@ -29,7 +31,9 @@
             "no_group",
             "goto_rebel_ninja_by_guide"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        }
     },
     "rebel_ninja_gameplay": {
         "recognition": "TemplateMatch",
@@ -59,7 +63,9 @@
             "rebel_ninja_mode",
             "[JumpBack]swipe_for_rebel_ninja_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        }
     },
     "rebel_ninja_mode": {
         "recognition": "TemplateMatch",
@@ -87,7 +93,9 @@
             "rebel_ninja_confirm_ninja",
             "rebel_ninja_summon_member"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入叛忍来袭</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入叛忍来袭</font>"
+        }
     },
     "rebel_ninja_finish": {
         "recognition": "OCR",
@@ -132,7 +140,9 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "<font color=\"DeepSkyBlue\">寻找叛忍模式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找叛忍模式</font>"
+        }
     },
     "rebel_ninja_not_open": {
         "recognition": "OCR",
@@ -189,7 +199,9 @@
             "rebel_ninja_go_fight",
             "[JumpBack]rebel_ninja_sleep_10s"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">等待开启</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">等待开启</font>"
+        }
     },
     "rebel_ninja_sleep_10s": {
         "post_delay": 10000
@@ -268,7 +280,9 @@
             "rebel_ninja_single_mode_checked",
             "[JumpBack]rebel_ninja_single_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">单倍奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">单倍奖励</font>"
+        }
     },
     "rebel_ninja_single_mode_checked": {
         "recognition": "TemplateMatch",
@@ -304,7 +318,9 @@
             "rebel_ninja_double_mode_checked",
             "[JumpBack]rebel_ninja_double_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">双倍奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">双倍奖励</font>"
+        }
     },
     "rebel_ninja_double_mode_checked": {
         "recognition": "TemplateMatch",
@@ -344,7 +360,9 @@
             "rebel_ninja_easy_mode_checked",
             "[JumpBack]rebel_ninja_easy_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">简单难度</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">简单难度</font>"
+        }
     },
     "rebel_ninja_easy_mode_checked": {
         "recognition": "TemplateMatch",
@@ -387,7 +405,9 @@
             "rebel_ninja_hard_mode_checked",
             "[JumpBack]rebel_ninja_hard_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">困难模式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">困难模式</font>"
+        }
     },
     "rebel_ninja_hard_mode_checked": {
         "recognition": "TemplateMatch",
@@ -495,7 +515,9 @@
             "[JumpBack]rebel_ninja_find_back_enemy",
             "rebel_ninja_not_find_enemy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">准备战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">准备战斗</font>"
+        }
     },
     "rebel_ninja_not_find_enemy": {
         "recognition": "OCR",
@@ -517,7 +539,9 @@
         ],
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"tomato\">找不到敌人,可能原因有识别阈值不够;目标敌人不在摇杆的右边;被组织成员遮挡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">找不到敌人,可能原因有识别阈值不够;目标敌人不在摇杆的右边;被组织成员遮挡</font>"
+        }
     },
     "rebel_ninja_find_back_enemy": {
         "max_hit": 10,
@@ -547,7 +571,9 @@
         ],
         "duration": 800,
         "post_delay": 1500,
-        "focus": "<font color=\"DeepSkyBlue\">那我再看看我后面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">那我再看看我后面</font>"
+        }
     },
     "rebel_ninja_only_me": {
         "enabled": false,
@@ -568,7 +594,9 @@
             "rebel_ninja_is_only_me",
             "rebel_ninja_set_only_me"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">设置只显示自己</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">设置只显示自己</font>"
+        }
     },
     "rebel_ninja_set_only_me": {
         "recognition": "TemplateMatch",
@@ -655,7 +683,9 @@
         ],
         "duration": 800,
         "post_delay": 1500,
-        "focus": "<font color=\"DeepSkyBlue\">寻找敌人</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找敌人</font>"
+        }
     },
     "rebel_ninja_low_enemy": {
         "recognition": "TemplateMatch",
@@ -676,7 +706,9 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_low_enemy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">低级敌人</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">低级敌人</font>"
+        }
     },
     "rebel_ninja_mid_enemy": {
         "recognition": "TemplateMatch",
@@ -697,7 +729,9 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_mid_enemy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">中级敌人</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">中级敌人</font>"
+        }
     },
     "rebel_ninja_high_enemy": {
         "recognition": "TemplateMatch",
@@ -718,7 +752,9 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_high_enemy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">高级敌人</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">高级敌人</font>"
+        }
     },
     "rebel_ninja_confirm_enemy": {
         "recognition": "TemplateMatch",
@@ -737,7 +773,9 @@
             "rebel_ninja_without_confirm_enemy",
             "[JumpBack]rebel_ninja_confirm_enemy"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">gogogo,出发喽</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">gogogo,出发喽</font>"
+        }
     },
     "rebel_ninja_without_confirm_enemy": {
         "recognition": "TemplateMatch",
@@ -777,7 +815,9 @@
             "rebel_ninja_in_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
+        }
     },
     "rebel_ninja_in_fight": {
         "recognition": "TemplateMatch",
@@ -830,7 +870,9 @@
         "next": [
             "rebel_ninja_auto_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
+        }
     },
     "rebel_ninja_direct_hit_quit": {
         "recognition": "OCR",
@@ -849,7 +891,9 @@
             "rebel_ninja_without_direct_hit_quit",
             "[JumpBack]rebel_ninja_direct_hit_quit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击任意地方退出</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击任意地方退出</font>"
+        }
     },
     "rebel_ninja_without_direct_hit_quit": {
         "recognition": "OCR",
@@ -878,6 +922,8 @@
         "threshold": 0.9,
         "action": "StopTask",
         "post_delay": 500,
-        "focus": "<font color=\"darkgray\">叛忍结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">叛忍结束</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Rebel_ninja.json
+++ b/assets/resource/base/pipeline/Rebel_ninja.json
@@ -11,7 +11,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入叛忍来袭任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入叛忍来袭任务</font>"
     },
     "goto_rebel_ninja_by_guide": {
         "recognition": "Custom",
@@ -29,7 +29,7 @@
             "no_group",
             "goto_rebel_ninja_by_guide"
         ],
-        "focus": "[color:DeepSkyBlue]组织主界面入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
     },
     "rebel_ninja_gameplay": {
         "recognition": "TemplateMatch",
@@ -59,7 +59,7 @@
             "rebel_ninja_mode",
             "[JumpBack]swipe_for_rebel_ninja_mode"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中组织玩法按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
     },
     "rebel_ninja_mode": {
         "recognition": "TemplateMatch",
@@ -87,7 +87,7 @@
             "rebel_ninja_confirm_ninja",
             "rebel_ninja_summon_member"
         ],
-        "focus": "[color:DeepSkyBlue]进入叛忍来袭[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入叛忍来袭</font>"
     },
     "rebel_ninja_finish": {
         "recognition": "OCR",
@@ -132,7 +132,7 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "[color:DeepSkyBlue]寻找叛忍模式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找叛忍模式</font>"
     },
     "rebel_ninja_not_open": {
         "recognition": "OCR",
@@ -189,7 +189,7 @@
             "rebel_ninja_go_fight",
             "[JumpBack]rebel_ninja_sleep_10s"
         ],
-        "focus": "[color:DeepSkyBlue]等待开启[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">等待开启</font>"
     },
     "rebel_ninja_sleep_10s": {
         "post_delay": 10000
@@ -268,7 +268,7 @@
             "rebel_ninja_single_mode_checked",
             "[JumpBack]rebel_ninja_single_mode"
         ],
-        "focus": "[color:DeepSkyBlue]单倍奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">单倍奖励</font>"
     },
     "rebel_ninja_single_mode_checked": {
         "recognition": "TemplateMatch",
@@ -304,7 +304,7 @@
             "rebel_ninja_double_mode_checked",
             "[JumpBack]rebel_ninja_double_mode"
         ],
-        "focus": "[color:DeepSkyBlue]双倍奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">双倍奖励</font>"
     },
     "rebel_ninja_double_mode_checked": {
         "recognition": "TemplateMatch",
@@ -344,7 +344,7 @@
             "rebel_ninja_easy_mode_checked",
             "[JumpBack]rebel_ninja_easy_mode"
         ],
-        "focus": "[color:DeepSkyBlue]简单难度[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">简单难度</font>"
     },
     "rebel_ninja_easy_mode_checked": {
         "recognition": "TemplateMatch",
@@ -387,7 +387,7 @@
             "rebel_ninja_hard_mode_checked",
             "[JumpBack]rebel_ninja_hard_mode"
         ],
-        "focus": "[color:DeepSkyBlue]困难模式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">困难模式</font>"
     },
     "rebel_ninja_hard_mode_checked": {
         "recognition": "TemplateMatch",
@@ -495,7 +495,7 @@
             "[JumpBack]rebel_ninja_find_back_enemy",
             "rebel_ninja_not_find_enemy"
         ],
-        "focus": "[color:DeepSkyBlue]准备战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">准备战斗</font>"
     },
     "rebel_ninja_not_find_enemy": {
         "recognition": "OCR",
@@ -517,7 +517,7 @@
         ],
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:tomato]找不到敌人,可能原因有识别阈值不够;目标敌人不在摇杆的右边;被组织成员遮挡[/color]"
+        "focus": "<font color=\"tomato\">找不到敌人,可能原因有识别阈值不够;目标敌人不在摇杆的右边;被组织成员遮挡</font>"
     },
     "rebel_ninja_find_back_enemy": {
         "max_hit": 10,
@@ -547,7 +547,7 @@
         ],
         "duration": 800,
         "post_delay": 1500,
-        "focus": "[color:DeepSkyBlue]那我再看看我后面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">那我再看看我后面</font>"
     },
     "rebel_ninja_only_me": {
         "enabled": false,
@@ -568,7 +568,7 @@
             "rebel_ninja_is_only_me",
             "rebel_ninja_set_only_me"
         ],
-        "focus": "[color:DeepSkyBlue]设置只显示自己[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">设置只显示自己</font>"
     },
     "rebel_ninja_set_only_me": {
         "recognition": "TemplateMatch",
@@ -655,7 +655,7 @@
         ],
         "duration": 800,
         "post_delay": 1500,
-        "focus": "[color:DeepSkyBlue]寻找敌人[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找敌人</font>"
     },
     "rebel_ninja_low_enemy": {
         "recognition": "TemplateMatch",
@@ -676,7 +676,7 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_low_enemy"
         ],
-        "focus": "[color:DeepSkyBlue]低级敌人[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">低级敌人</font>"
     },
     "rebel_ninja_mid_enemy": {
         "recognition": "TemplateMatch",
@@ -697,7 +697,7 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_mid_enemy"
         ],
-        "focus": "[color:DeepSkyBlue]中级敌人[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">中级敌人</font>"
     },
     "rebel_ninja_high_enemy": {
         "recognition": "TemplateMatch",
@@ -718,7 +718,7 @@
             "rebel_ninja_confirm_enemy",
             "[JumpBack]rebel_ninja_high_enemy"
         ],
-        "focus": "[color:DeepSkyBlue]高级敌人[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">高级敌人</font>"
     },
     "rebel_ninja_confirm_enemy": {
         "recognition": "TemplateMatch",
@@ -737,7 +737,7 @@
             "rebel_ninja_without_confirm_enemy",
             "[JumpBack]rebel_ninja_confirm_enemy"
         ],
-        "focus": "[color:DeepSkyBlue]gogogo,出发喽[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">gogogo,出发喽</font>"
     },
     "rebel_ninja_without_confirm_enemy": {
         "recognition": "TemplateMatch",
@@ -777,7 +777,7 @@
             "rebel_ninja_in_fight",
             "[JumpBack]wait_5_second"
         ],
-        "focus": "[color:DeepSkyBlue]打开自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">打开自动战斗</font>"
     },
     "rebel_ninja_in_fight": {
         "recognition": "TemplateMatch",
@@ -830,7 +830,7 @@
         "next": [
             "rebel_ninja_auto_fight"
         ],
-        "focus": "[color:DeepSkyBlue]不在自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">不在自动战斗</font>"
     },
     "rebel_ninja_direct_hit_quit": {
         "recognition": "OCR",
@@ -849,7 +849,7 @@
             "rebel_ninja_without_direct_hit_quit",
             "[JumpBack]rebel_ninja_direct_hit_quit"
         ],
-        "focus": "[color:DeepSkyBlue]点击任意地方退出[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击任意地方退出</font>"
     },
     "rebel_ninja_without_direct_hit_quit": {
         "recognition": "OCR",
@@ -878,6 +878,6 @@
         "threshold": 0.9,
         "action": "StopTask",
         "post_delay": 500,
-        "focus": "[color:darkgray]叛忍结束[/color]"
+        "focus": "<font color=\"darkgray\">叛忍结束</font>"
     }
 }

--- a/assets/resource/base/pipeline/Red_envelope.json
+++ b/assets/resource/base/pipeline/Red_envelope.json
@@ -6,7 +6,9 @@
             "[JumpBack]get_red_envelope",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入抢红包任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入抢红包任务</font>"
+        }
     },
     "red_envelope_to_activity": {
         "recognition": "TemplateMatch",
@@ -30,7 +32,9 @@
             "red_envelope_check_in_activity",
             "red_envelope_to_activity"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "red_envelope_check_in_activity": {
         "recognition": "OCR",
@@ -47,7 +51,9 @@
         "next": [
             "swipes_for_red_envelope"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "swipes_for_red_envelope": {
         "action": "Swipe",
@@ -70,7 +76,9 @@
             "swipes_for_red_envelope",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">寻找红包任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找红包任务</font>"
+        }
     },
     "red_envelope_entry": {
         "max_hit": 5,
@@ -90,7 +98,9 @@
             "check_selected_red_envelope",
             "[JumpBack]red_envelope_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入红包任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入红包任务</font>"
+        }
     },
     "check_selected_red_envelope": {
         "recognition": "TemplateMatch",
@@ -104,7 +114,9 @@
         "next": [
             "red_envelope_to_fire_work"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中红包任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中红包任务</font>"
+        }
     },
     "red_envelope_to_fire_work": {
         "recognition": "OCR",
@@ -125,7 +137,9 @@
             "[JumpBack]red_envelope_to_fire_work",
             "[JumpBack]get_red_envelope"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入烟花界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入烟花界面</font>"
+        }
     },
     "red_envelope_in_fire_work": {
         "recognition": "OCR",
@@ -135,7 +149,9 @@
         "next": [
             "red_envelope_clicker_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认在烟花界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认在烟花界面</font>"
+        }
     },
     "red_envelope_clicker_1": {
         "action": "Click",
@@ -148,7 +164,9 @@
         "next": [
             "red_envelope_clicker_2"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">抢红包连点器</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">抢红包连点器</font>"
+        }
     },
     "red_envelope_clicker_2": {
         "action": "Click",
@@ -176,7 +194,9 @@
             "without_red_envelope",
             "[JumpBack]get_red_envelope"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取红包雨</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取红包雨</font>"
+        }
     },
     "without_red_envelope": {
         "recognition": "TemplateMatch",
@@ -188,6 +208,8 @@
         ],
         "template": "Red_envelope/christmas_stocking.png",
         "inverse": true,
-        "focus": "<font color=\"DeepSkyBlue\">离开红包雨</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">离开红包雨</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Red_envelope.json
+++ b/assets/resource/base/pipeline/Red_envelope.json
@@ -6,7 +6,7 @@
             "[JumpBack]get_red_envelope",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入抢红包任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入抢红包任务</font>"
     },
     "red_envelope_to_activity": {
         "recognition": "TemplateMatch",
@@ -30,7 +30,7 @@
             "red_envelope_check_in_activity",
             "red_envelope_to_activity"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "red_envelope_check_in_activity": {
         "recognition": "OCR",
@@ -47,7 +47,7 @@
         "next": [
             "swipes_for_red_envelope"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "swipes_for_red_envelope": {
         "action": "Swipe",
@@ -70,7 +70,7 @@
             "swipes_for_red_envelope",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]寻找红包任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找红包任务</font>"
     },
     "red_envelope_entry": {
         "max_hit": 5,
@@ -90,7 +90,7 @@
             "check_selected_red_envelope",
             "[JumpBack]red_envelope_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入红包任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入红包任务</font>"
     },
     "check_selected_red_envelope": {
         "recognition": "TemplateMatch",
@@ -104,7 +104,7 @@
         "next": [
             "red_envelope_to_fire_work"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中红包任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中红包任务</font>"
     },
     "red_envelope_to_fire_work": {
         "recognition": "OCR",
@@ -125,7 +125,7 @@
             "[JumpBack]red_envelope_to_fire_work",
             "[JumpBack]get_red_envelope"
         ],
-        "focus": "[color:DeepSkyBlue]进入烟花界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入烟花界面</font>"
     },
     "red_envelope_in_fire_work": {
         "recognition": "OCR",
@@ -135,7 +135,7 @@
         "next": [
             "red_envelope_clicker_1"
         ],
-        "focus": "[color:DeepSkyBlue]确认在烟花界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认在烟花界面</font>"
     },
     "red_envelope_clicker_1": {
         "action": "Click",
@@ -148,7 +148,7 @@
         "next": [
             "red_envelope_clicker_2"
         ],
-        "focus": "[color:DeepSkyBlue]抢红包连点器[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">抢红包连点器</font>"
     },
     "red_envelope_clicker_2": {
         "action": "Click",
@@ -176,7 +176,7 @@
             "without_red_envelope",
             "[JumpBack]get_red_envelope"
         ],
-        "focus": "[color:DeepSkyBlue]领取红包雨[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取红包雨</font>"
     },
     "without_red_envelope": {
         "recognition": "TemplateMatch",
@@ -188,6 +188,6 @@
         ],
         "template": "Red_envelope/christmas_stocking.png",
         "inverse": true,
-        "focus": "[color:DeepSkyBlue]离开红包雨[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">离开红包雨</font>"
     }
 }

--- a/assets/resource/base/pipeline/Rich_room.json
+++ b/assets/resource/base/pipeline/Rich_room.json
@@ -7,7 +7,9 @@
             "rich_room_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入丰饶之间任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入丰饶之间任务</font>"
+        }
     },
     "rich_room_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +28,9 @@
             "award_center_find_end",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "rich_room_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -44,7 +48,9 @@
             "rich_room_in_center_enter",
             "rich_room_not_in_center_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        }
     },
     "rich_room_ac_entry": {
         "recognition": "TemplateMatch",
@@ -67,7 +73,9 @@
             "rich_room_not_in_center_enter",
             "rich_room_ac_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        }
     },
     "rich_room_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -93,7 +101,9 @@
             "rich_room_in_rich_room",
             "rich_room_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">丰饶之间未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">丰饶之间未完成</font>"
+        }
     },
     "rich_room_in_rich_room": {
         "recognition": "OCR",
@@ -277,7 +287,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">丰饶之间完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">丰饶之间完成</font>"
+        }
     },
     "rich_room_ninja_expire": {
         "recognition": "OCR",
@@ -311,7 +323,9 @@
             "rich_room_in_lineup",
             "rich_room_lineup"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">丰饶之间调整阵容</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">丰饶之间调整阵容</font>"
+        }
     },
     "rich_room_in_lineup": {
         "recognition": "OCR",
@@ -446,7 +460,9 @@
             "rich_room_in_select_roll",
             "[JumpBack]rich_room_to_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
+        }
     },
     "rich_room_in_select_roll": {
         "recognition": "TemplateMatch",
@@ -463,7 +479,9 @@
             "rich_room_selected_roll",
             "rich_room_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
+        }
     },
     "rich_room_select_roll": {
         "recognition": "TemplateMatch",
@@ -483,7 +501,9 @@
             "rich_room_selected_roll",
             "rich_room_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">识别密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">识别密卷</font>"
+        }
     },
     "rich_room_selected_roll": {
         "recognition": "OCR",
@@ -498,7 +518,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "rich_room_confirm_set",
-        "focus": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
+        }
     },
     "rich_room_confirm_set": {
         "recognition": "OCR",
@@ -531,7 +553,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检查是否和平</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检查是否和平</font>"
+        }
     },
     "rich_room_in_fight": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Rich_room.json
+++ b/assets/resource/base/pipeline/Rich_room.json
@@ -7,7 +7,7 @@
             "rich_room_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入丰饶之间任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入丰饶之间任务</font>"
     },
     "rich_room_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +26,7 @@
             "award_center_find_end",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "rich_room_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -44,7 +44,7 @@
             "rich_room_in_center_enter",
             "rich_room_not_in_center_enter"
         ],
-        "focus": "[color:DeepSkyBlue]奖励中心有奖励没领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
     },
     "rich_room_ac_entry": {
         "recognition": "TemplateMatch",
@@ -67,7 +67,7 @@
             "rich_room_not_in_center_enter",
             "rich_room_ac_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
     },
     "rich_room_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -93,7 +93,7 @@
             "rich_room_in_rich_room",
             "rich_room_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]丰饶之间未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">丰饶之间未完成</font>"
     },
     "rich_room_in_rich_room": {
         "recognition": "OCR",
@@ -277,7 +277,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]丰饶之间完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">丰饶之间完成</font>"
     },
     "rich_room_ninja_expire": {
         "recognition": "OCR",
@@ -311,7 +311,7 @@
             "rich_room_in_lineup",
             "rich_room_lineup"
         ],
-        "focus": "[color:DeepSkyBlue]丰饶之间调整阵容[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">丰饶之间调整阵容</font>"
     },
     "rich_room_in_lineup": {
         "recognition": "OCR",
@@ -446,7 +446,7 @@
             "rich_room_in_select_roll",
             "[JumpBack]rich_room_to_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]选择秘卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
     },
     "rich_room_in_select_roll": {
         "recognition": "TemplateMatch",
@@ -463,7 +463,7 @@
             "rich_room_selected_roll",
             "rich_room_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]开始选择密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
     },
     "rich_room_select_roll": {
         "recognition": "TemplateMatch",
@@ -483,7 +483,7 @@
             "rich_room_selected_roll",
             "rich_room_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]识别密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">识别密卷</font>"
     },
     "rich_room_selected_roll": {
         "recognition": "OCR",
@@ -498,7 +498,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "rich_room_confirm_set",
-        "focus": "[color:DeepSkyBlue]完成选择密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
     },
     "rich_room_confirm_set": {
         "recognition": "OCR",
@@ -531,7 +531,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]检查是否和平[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检查是否和平</font>"
     },
     "rich_room_in_fight": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Routine.json
+++ b/assets/resource/base/pipeline/Routine.json
@@ -2,7 +2,9 @@
     "complete": {
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "OK",
+        "focus": {
+            "Node.Action.Starting": "OK"
+        },
         "$doc": "用来标记全部任务已经完成,和auto_mas配合"
     },
     "cleanup_maafw_bak_logs": {

--- a/assets/resource/base/pipeline/Secondary_password.json
+++ b/assets/resource/base/pipeline/Secondary_password.json
@@ -6,7 +6,9 @@
             "secondary_password_in_main",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"pink\">进入解锁二级密码任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">进入解锁二级密码任务</font>"
+        }
     },
     "secondary_password_in_main": {
         "recognition": "Or",

--- a/assets/resource/base/pipeline/Secondary_password.json
+++ b/assets/resource/base/pipeline/Secondary_password.json
@@ -6,7 +6,7 @@
             "secondary_password_in_main",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:pink]进入解锁二级密码任务[/color]"
+        "focus": "<font color=\"pink\">进入解锁二级密码任务</font>"
     },
     "secondary_password_in_main": {
         "recognition": "Or",

--- a/assets/resource/base/pipeline/Secret_realm.json
+++ b/assets/resource/base/pipeline/Secret_realm.json
@@ -10,7 +10,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
+        }
     },
     "open_secret_realm_by_guide": {
         "recognition": "Custom",
@@ -51,7 +53,9 @@
             "secret_realm_fight",
             "secret_realm_create_room"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境开房间</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境开房间</font>"
+        }
     },
     "secret_realm_fight": {
         "recognition": "TemplateMatch",
@@ -71,7 +75,9 @@
             "[JumpBack]secret_realm_stop_remind",
             "secret_realm_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境出战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境出战</font>"
+        }
     },
     "secret_realm_check_ticket": {
         "recognition": "TemplateMatch",
@@ -108,7 +114,9 @@
             "[JumpBack]secret_realm_stop_remind",
             "secret_realm_go_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境出战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境出战</font>"
+        }
     },
     "secret_realm_stop_remind": {
         "recognition": "TemplateMatch",
@@ -127,7 +135,9 @@
             "secret_realm_stop_remind_check",
             "secret_realm_stop_remind"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境挑战卷提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境挑战卷提示</font>"
+        }
     },
     "secret_realm_stop_remind_check": {
         "recognition": "TemplateMatch",
@@ -145,7 +155,9 @@
             "secret_realm_confirm_stop_remind",
             "secret_realm_stop_remind_check"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境选中关闭挑战卷提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境选中关闭挑战卷提示</font>"
+        }
     },
     "secret_realm_confirm_stop_remind": {
         "recognition": "OCR",
@@ -166,7 +178,9 @@
             "secret_realm_without_confirm_stop_remind",
             "secret_realm_confirm_stop_remind"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境关闭挑战卷提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境关闭挑战卷提示</font>"
+        }
     },
     "secret_realm_without_confirm_stop_remind": {
         "recognition": "OCR",
@@ -229,7 +243,9 @@
             "secret_realm_fight"
         ],
         "on_error": "battle_failed",
-        "focus": "<font color=\"DeepSkyBlue\">秘境战斗中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境战斗中</font>"
+        }
     },
     "secret_realm_toxic_wind": {
         "recognition": "TemplateMatch",
@@ -243,7 +259,9 @@
         "next": [
             "secret_realm_toxic_wind_to_place"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">毒风秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">毒风秘境</font>"
+        }
     },
     "secret_realm_toxic_wind_to_place": {
         "recognition": "TemplateMatch",
@@ -271,7 +289,9 @@
         "next": [
             "secret_realm_toxic_wind_to_place_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往毒风秘境封印处</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往毒风秘境封印处</font>"
+        }
     },
     "secret_realm_toxic_wind_to_place_1": {
         "action": "Swipe",
@@ -380,7 +400,9 @@
         "next": [
             "secret_realm_yin_yang_to_place"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">阴阳秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">阴阳秘境</font>"
+        }
     },
     "secret_realm_yin_yang_to_place": {
         "recognition": "TemplateMatch",
@@ -408,7 +430,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往阴阳秘境阳染色处</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往阴阳秘境阳染色处</font>"
+        }
     },
     "secret_realm_rock": {
         "recognition": "TemplateMatch",
@@ -422,7 +446,9 @@
         "next": [
             "secret_realm_rock_to_place"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">落岩秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">落岩秘境</font>"
+        }
     },
     "secret_realm_rock_to_place": {
         "recognition": "TemplateMatch",
@@ -450,7 +476,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往落岩秘境指定战斗处</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往落岩秘境指定战斗处</font>"
+        }
     },
     "secret_realm_thunder": {
         "recognition": "TemplateMatch",
@@ -464,7 +492,9 @@
         "next": [
             "secret_realm_thunder_to_place"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">雷霆秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">雷霆秘境</font>"
+        }
     },
     "secret_realm_thunder_to_place": {
         "recognition": "TemplateMatch",
@@ -492,7 +522,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往雷霆秘境指定战斗处</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往雷霆秘境指定战斗处</font>"
+        }
     },
     "secret_realm_water": {
         "recognition": "TemplateMatch",
@@ -506,7 +538,9 @@
         "next": [
             "secret_realm_water_to_place"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">水牢秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">水牢秘境</font>"
+        }
     },
     "secret_realm_water_to_place": {
         "recognition": "TemplateMatch",
@@ -534,7 +568,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往水牢秘境指定战斗处</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往水牢秘境指定战斗处</font>"
+        }
     },
     "secret_realm_body": {
         "recognition": "TemplateMatch",
@@ -550,7 +586,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">罡体秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">罡体秘境</font>"
+        }
     },
     "secret_realm_fire": {
         "recognition": "TemplateMatch",
@@ -566,7 +604,9 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">烈炎秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">烈炎秘境</font>"
+        }
     },
     "secret_realm_settlement": {
         "recognition": "OCR",
@@ -589,7 +629,9 @@
             "secret_realm_celebreate",
             "secret_realm_celebreate_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">副本结算</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">副本结算</font>"
+        }
     },
     "secret_realm_old_settlement": {
         "recognition": "OCR",
@@ -615,7 +657,9 @@
             "secret_realm_celebreate_1",
             "secret_realm_old_settlement"
         ],
-        "focus": "<font color=\"DarkGoldenRod\">副本结算</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DarkGoldenRod\">副本结算</font>"
+        }
     },
     "secret_realm_wasted": {
         "recognition": "TemplateMatch",
@@ -632,7 +676,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 200,
-        "focus": "<font color=\"DeepSkyBlue\">秘境失败</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境失败</font>"
+        }
     },
     "secret_realm_win": {
         "recognition": "TemplateMatch",
@@ -658,7 +704,9 @@
             "secret_realm_celebreate_1",
             "[JumpBack]secret_realm_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
+        }
     },
     "secret_realm_check_in_main": {
         "recognition": "TemplateMatch",
@@ -690,7 +738,9 @@
         "next": [
             "secret_realm_back_main_sceen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境最后一次</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境最后一次</font>"
+        }
     },
     "secret_realm_back_main_sceen": {
         "recognition": "TemplateMatch",
@@ -709,7 +759,9 @@
             "secret_realm_quit_team",
             "[JumpBack]secret_realm_back_main_sceen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境开始回主页面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境开始回主页面</font>"
+        }
     },
     "secret_realm_quit_team": {
         "recognition": "OCR",
@@ -730,7 +782,9 @@
             "secret_realm_quit_secret_realm",
             "[JumpBack]secret_realm_quit_team"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境退队</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境退队</font>"
+        }
     },
     "secret_realm_quit_secret_realm": {
         "recognition": "TemplateMatch",
@@ -749,7 +803,9 @@
             "secret_realm_quit_ninja_challenge",
             "[JumpBack]secret_realm_quit_secret_realm"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境离开秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境离开秘境</font>"
+        }
     },
     "secret_realm_quit_ninja_challenge": {
         "recognition": "TemplateMatch",
@@ -770,7 +826,9 @@
             "secret_realm_quit_team",
             "[JumpBack]secret_realm_quit_ninja_challenge"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境离开忍者挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境离开忍者挑战</font>"
+        }
     },
     "secret_realm_without_ninja_challenge": {
         "recognition": "TemplateMatch",
@@ -809,7 +867,9 @@
             "secret_realm_celebreate_1",
             "secret_realm_counter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境奖励</font>"
+        }
     },
     "secret_realm_celebreate_1": {
         "recognition": "TemplateMatch",
@@ -837,7 +897,9 @@
             "secret_realm_celebreate_1",
             "secret_realm_counter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境奖励</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境奖励</font>"
+        },
         "$doc": "这个节点用来防止文字被遮挡的情况"
     },
     "secret_realm_counter": {
@@ -858,7 +920,9 @@
         },
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "再次进行秘境挑战",
+        "focus": {
+            "Node.Action.Starting": "再次进行秘境挑战"
+        },
         "$doc": "Jumpback to 'secret_realm_fight'"
     },
     "secret_realm_quit": {
@@ -877,7 +941,9 @@
             "secret_realm_quit_button",
             "[JumpBack]secret_realm_quit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">退出未选择秘境秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">退出未选择秘境秘境</font>"
+        }
     },
     "secret_realm_quit_button": {
         "recognition": "OCR",
@@ -897,7 +963,9 @@
             "confirm_secret_realm_quit",
             "secret_realm_quit_button"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境</font>"
+        }
     },
     "confirm_secret_realm_quit": {
         "recognition": "OCR",
@@ -940,7 +1008,9 @@
             "secret_realm_gear_card",
             "secret_realm_win_back_secret_realm"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">饰品牌可翻</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">饰品牌可翻</font>"
+        }
     },
     "secret_realm_flip_without_card": {
         "enabled": false,
@@ -968,7 +1038,9 @@
             "secret_realm_celebreate_1",
             "secret_realm_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">无可翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">无可翻牌</font>"
+        }
     },
     "secret_realm_without_accessory_card": {
         "recognition": "TemplateMatch",
@@ -985,7 +1057,9 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
+        }
     },
     "secret_realm_without_gear_card": {
         "recognition": "TemplateMatch",
@@ -1002,7 +1076,9 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
+        }
     },
     "secret_realm_accessory_card": {
         "recognition": "TemplateMatch",
@@ -1023,7 +1099,9 @@
             "secret_realm_flip_accessory_card",
             "secret_realm_without_accessory_card"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">有饰品翻牌卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">有饰品翻牌卷</font>"
+        }
     },
     "secret_realm_gear_card": {
         "recognition": "TemplateMatch",
@@ -1044,7 +1122,9 @@
             "secret_realm_flip_gear_card",
             "secret_realm_without_gear_card"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">有忍具翻牌卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">有忍具翻牌卷</font>"
+        }
     },
     "secret_realm_flip_accessory_card": {
         "recognition": "TemplateMatch",
@@ -1061,7 +1141,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">饰品翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">饰品翻牌</font>"
+        }
     },
     "secret_realm_flip_gear_card": {
         "recognition": "TemplateMatch",
@@ -1078,7 +1160,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">忍具翻牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忍具翻牌</font>"
+        }
     },
     "secret_realm_win_back_secret_realm": {
         "recognition": "TemplateMatch",
@@ -1104,7 +1188,9 @@
         "on_error": [
             "secret_realm_back_main_sceen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
+        }
     },
     "secret_realm_click_All_skill": {
         "recognition": "TemplateMatch",
@@ -1250,7 +1336,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "secret_realm_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1276,7 +1364,9 @@
             "secret_realm_create_room",
             "secret_realm_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">秘境探险未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">秘境探险未完成</font>"
+        }
     },
     "secret_realm_combo_attack": {
         "pre_delay": 0,

--- a/assets/resource/base/pipeline/Secret_realm.json
+++ b/assets/resource/base/pipeline/Secret_realm.json
@@ -10,7 +10,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入秘境子任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入秘境子任务</font>"
     },
     "open_secret_realm_by_guide": {
         "recognition": "Custom",
@@ -51,7 +51,7 @@
             "secret_realm_fight",
             "secret_realm_create_room"
         ],
-        "focus": "[color:DeepSkyBlue]秘境开房间[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境开房间</font>"
     },
     "secret_realm_fight": {
         "recognition": "TemplateMatch",
@@ -71,7 +71,7 @@
             "[JumpBack]secret_realm_stop_remind",
             "secret_realm_fight"
         ],
-        "focus": "[color:DeepSkyBlue]秘境出战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境出战</font>"
     },
     "secret_realm_check_ticket": {
         "recognition": "TemplateMatch",
@@ -108,7 +108,7 @@
             "[JumpBack]secret_realm_stop_remind",
             "secret_realm_go_fight"
         ],
-        "focus": "[color:DeepSkyBlue]秘境出战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境出战</font>"
     },
     "secret_realm_stop_remind": {
         "recognition": "TemplateMatch",
@@ -127,7 +127,7 @@
             "secret_realm_stop_remind_check",
             "secret_realm_stop_remind"
         ],
-        "focus": "[color:DeepSkyBlue]秘境挑战卷提示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境挑战卷提示</font>"
     },
     "secret_realm_stop_remind_check": {
         "recognition": "TemplateMatch",
@@ -145,7 +145,7 @@
             "secret_realm_confirm_stop_remind",
             "secret_realm_stop_remind_check"
         ],
-        "focus": "[color:DeepSkyBlue]秘境选中关闭挑战卷提示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境选中关闭挑战卷提示</font>"
     },
     "secret_realm_confirm_stop_remind": {
         "recognition": "OCR",
@@ -166,7 +166,7 @@
             "secret_realm_without_confirm_stop_remind",
             "secret_realm_confirm_stop_remind"
         ],
-        "focus": "[color:DeepSkyBlue]秘境关闭挑战卷提示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境关闭挑战卷提示</font>"
     },
     "secret_realm_without_confirm_stop_remind": {
         "recognition": "OCR",
@@ -229,7 +229,7 @@
             "secret_realm_fight"
         ],
         "on_error": "battle_failed",
-        "focus": "[color:DeepSkyBlue]秘境战斗中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境战斗中</font>"
     },
     "secret_realm_toxic_wind": {
         "recognition": "TemplateMatch",
@@ -243,7 +243,7 @@
         "next": [
             "secret_realm_toxic_wind_to_place"
         ],
-        "focus": "[color:DeepSkyBlue]毒风秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">毒风秘境</font>"
     },
     "secret_realm_toxic_wind_to_place": {
         "recognition": "TemplateMatch",
@@ -271,7 +271,7 @@
         "next": [
             "secret_realm_toxic_wind_to_place_1"
         ],
-        "focus": "[color:DeepSkyBlue]前往毒风秘境封印处[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往毒风秘境封印处</font>"
     },
     "secret_realm_toxic_wind_to_place_1": {
         "action": "Swipe",
@@ -380,7 +380,7 @@
         "next": [
             "secret_realm_yin_yang_to_place"
         ],
-        "focus": "[color:DeepSkyBlue]阴阳秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">阴阳秘境</font>"
     },
     "secret_realm_yin_yang_to_place": {
         "recognition": "TemplateMatch",
@@ -408,7 +408,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]前往阴阳秘境阳染色处[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往阴阳秘境阳染色处</font>"
     },
     "secret_realm_rock": {
         "recognition": "TemplateMatch",
@@ -422,7 +422,7 @@
         "next": [
             "secret_realm_rock_to_place"
         ],
-        "focus": "[color:DeepSkyBlue]落岩秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">落岩秘境</font>"
     },
     "secret_realm_rock_to_place": {
         "recognition": "TemplateMatch",
@@ -450,7 +450,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]前往落岩秘境指定战斗处[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往落岩秘境指定战斗处</font>"
     },
     "secret_realm_thunder": {
         "recognition": "TemplateMatch",
@@ -464,7 +464,7 @@
         "next": [
             "secret_realm_thunder_to_place"
         ],
-        "focus": "[color:DeepSkyBlue]雷霆秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">雷霆秘境</font>"
     },
     "secret_realm_thunder_to_place": {
         "recognition": "TemplateMatch",
@@ -492,7 +492,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]前往雷霆秘境指定战斗处[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往雷霆秘境指定战斗处</font>"
     },
     "secret_realm_water": {
         "recognition": "TemplateMatch",
@@ -506,7 +506,7 @@
         "next": [
             "secret_realm_water_to_place"
         ],
-        "focus": "[color:DeepSkyBlue]水牢秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">水牢秘境</font>"
     },
     "secret_realm_water_to_place": {
         "recognition": "TemplateMatch",
@@ -534,7 +534,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]前往水牢秘境指定战斗处[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往水牢秘境指定战斗处</font>"
     },
     "secret_realm_body": {
         "recognition": "TemplateMatch",
@@ -550,7 +550,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]罡体秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">罡体秘境</font>"
     },
     "secret_realm_fire": {
         "recognition": "TemplateMatch",
@@ -566,7 +566,7 @@
         "next": [
             "secret_realm_in_fight"
         ],
-        "focus": "[color:DeepSkyBlue]烈炎秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">烈炎秘境</font>"
     },
     "secret_realm_settlement": {
         "recognition": "OCR",
@@ -589,7 +589,7 @@
             "secret_realm_celebreate",
             "secret_realm_celebreate_1"
         ],
-        "focus": "[color:DeepSkyBlue]副本结算[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">副本结算</font>"
     },
     "secret_realm_old_settlement": {
         "recognition": "OCR",
@@ -615,7 +615,7 @@
             "secret_realm_celebreate_1",
             "secret_realm_old_settlement"
         ],
-        "focus": "[color:DarkGoldenRod]副本结算[/color]"
+        "focus": "<font color=\"DarkGoldenRod\">副本结算</font>"
     },
     "secret_realm_wasted": {
         "recognition": "TemplateMatch",
@@ -632,7 +632,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 200,
-        "focus": "[color:DeepSkyBlue]秘境失败[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境失败</font>"
     },
     "secret_realm_win": {
         "recognition": "TemplateMatch",
@@ -658,7 +658,7 @@
             "secret_realm_celebreate_1",
             "[JumpBack]secret_realm_win"
         ],
-        "focus": "[color:DeepSkyBlue]秘境胜利[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
     },
     "secret_realm_check_in_main": {
         "recognition": "TemplateMatch",
@@ -690,7 +690,7 @@
         "next": [
             "secret_realm_back_main_sceen"
         ],
-        "focus": "[color:DeepSkyBlue]秘境最后一次[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境最后一次</font>"
     },
     "secret_realm_back_main_sceen": {
         "recognition": "TemplateMatch",
@@ -709,7 +709,7 @@
             "secret_realm_quit_team",
             "[JumpBack]secret_realm_back_main_sceen"
         ],
-        "focus": "[color:DeepSkyBlue]秘境开始回主页面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境开始回主页面</font>"
     },
     "secret_realm_quit_team": {
         "recognition": "OCR",
@@ -730,7 +730,7 @@
             "secret_realm_quit_secret_realm",
             "[JumpBack]secret_realm_quit_team"
         ],
-        "focus": "[color:DeepSkyBlue]秘境退队[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境退队</font>"
     },
     "secret_realm_quit_secret_realm": {
         "recognition": "TemplateMatch",
@@ -749,7 +749,7 @@
             "secret_realm_quit_ninja_challenge",
             "[JumpBack]secret_realm_quit_secret_realm"
         ],
-        "focus": "[color:DeepSkyBlue]秘境离开秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境离开秘境</font>"
     },
     "secret_realm_quit_ninja_challenge": {
         "recognition": "TemplateMatch",
@@ -770,7 +770,7 @@
             "secret_realm_quit_team",
             "[JumpBack]secret_realm_quit_ninja_challenge"
         ],
-        "focus": "[color:DeepSkyBlue]秘境离开忍者挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境离开忍者挑战</font>"
     },
     "secret_realm_without_ninja_challenge": {
         "recognition": "TemplateMatch",
@@ -809,7 +809,7 @@
             "secret_realm_celebreate_1",
             "secret_realm_counter"
         ],
-        "focus": "[color:DeepSkyBlue]秘境奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境奖励</font>"
     },
     "secret_realm_celebreate_1": {
         "recognition": "TemplateMatch",
@@ -837,7 +837,7 @@
             "secret_realm_celebreate_1",
             "secret_realm_counter"
         ],
-        "focus": "[color:DeepSkyBlue]秘境奖励[/color]",
+        "focus": "<font color=\"DeepSkyBlue\">秘境奖励</font>",
         "$doc": "这个节点用来防止文字被遮挡的情况"
     },
     "secret_realm_counter": {
@@ -877,7 +877,7 @@
             "secret_realm_quit_button",
             "[JumpBack]secret_realm_quit"
         ],
-        "focus": "[color:DeepSkyBlue]退出未选择秘境秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">退出未选择秘境秘境</font>"
     },
     "secret_realm_quit_button": {
         "recognition": "OCR",
@@ -897,7 +897,7 @@
             "confirm_secret_realm_quit",
             "secret_realm_quit_button"
         ],
-        "focus": "[color:DeepSkyBlue]秘境[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境</font>"
     },
     "confirm_secret_realm_quit": {
         "recognition": "OCR",
@@ -940,7 +940,7 @@
             "secret_realm_gear_card",
             "secret_realm_win_back_secret_realm"
         ],
-        "focus": "[color:DeepSkyBlue]饰品牌可翻[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">饰品牌可翻</font>"
     },
     "secret_realm_flip_without_card": {
         "enabled": false,
@@ -968,7 +968,7 @@
             "secret_realm_celebreate_1",
             "secret_realm_fight"
         ],
-        "focus": "[color:DeepSkyBlue]无可翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">无可翻牌</font>"
     },
     "secret_realm_without_accessory_card": {
         "recognition": "TemplateMatch",
@@ -985,7 +985,7 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]无可忍具翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
     },
     "secret_realm_without_gear_card": {
         "recognition": "TemplateMatch",
@@ -1002,7 +1002,7 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]无可忍具翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">无可忍具翻牌</font>"
     },
     "secret_realm_accessory_card": {
         "recognition": "TemplateMatch",
@@ -1023,7 +1023,7 @@
             "secret_realm_flip_accessory_card",
             "secret_realm_without_accessory_card"
         ],
-        "focus": "[color:DeepSkyBlue]有饰品翻牌卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">有饰品翻牌卷</font>"
     },
     "secret_realm_gear_card": {
         "recognition": "TemplateMatch",
@@ -1044,7 +1044,7 @@
             "secret_realm_flip_gear_card",
             "secret_realm_without_gear_card"
         ],
-        "focus": "[color:DeepSkyBlue]有忍具翻牌卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">有忍具翻牌卷</font>"
     },
     "secret_realm_flip_accessory_card": {
         "recognition": "TemplateMatch",
@@ -1061,7 +1061,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]饰品翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">饰品翻牌</font>"
     },
     "secret_realm_flip_gear_card": {
         "recognition": "TemplateMatch",
@@ -1078,7 +1078,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]忍具翻牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忍具翻牌</font>"
     },
     "secret_realm_win_back_secret_realm": {
         "recognition": "TemplateMatch",
@@ -1104,7 +1104,7 @@
         "on_error": [
             "secret_realm_back_main_sceen"
         ],
-        "focus": "[color:DeepSkyBlue]秘境胜利[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境胜利</font>"
     },
     "secret_realm_click_All_skill": {
         "recognition": "TemplateMatch",
@@ -1250,7 +1250,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "secret_realm_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1276,7 +1276,7 @@
             "secret_realm_create_room",
             "secret_realm_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]秘境探险未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">秘境探险未完成</font>"
     },
     "secret_realm_combo_attack": {
         "pre_delay": 0,

--- a/assets/resource/base/pipeline/Share.json
+++ b/assets/resource/base/pipeline/Share.json
@@ -8,13 +8,13 @@
             "share_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入分享任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入分享任务</font>"
     },
     "is_android_then_no_share": {
         "recognition": "Custom",
         "custom_recognition": "CheckIsAndroid",
         "next": "back_main_screen_and_stop",
-        "focus": "[color:darkorange]不支持在安卓上进行分享，请使用模拟器！[/color]"
+        "focus": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
     },
     "share_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -33,7 +33,7 @@
             "share_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "share_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -51,7 +51,7 @@
             "share_in_center_enter",
             "share_not_in_center_enter"
         ],
-        "focus": "[color:DeepSkyBlue]奖励中心有奖励没领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
     },
     "share_ac_entry": {
         "recognition": "TemplateMatch",
@@ -74,7 +74,7 @@
             "share_not_in_center_enter",
             "share_ac_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
     },
     "share_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -104,7 +104,7 @@
             "share_ac_entry_undone",
             "[JumpBack]share_entry"
         ],
-        "focus": "[color:DeepSkyBlue]分享未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">分享未完成</font>"
     },
     "share_ac_done": {
         "recognition": "TemplateMatch",
@@ -120,7 +120,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]分享已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">分享已完成</font>"
     },
     "share_entry": {
         "recognition": "TemplateMatch",
@@ -144,7 +144,7 @@
         ],
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:darkgray]尝试进入用户主页[/color]"
+        "focus": "<font color=\"darkgray\">尝试进入用户主页</font>"
     },
     "try_share": {
         "recognition": "TemplateMatch",
@@ -165,7 +165,7 @@
             "[JumpBack]share_close_weekly_ninja_title",
             "try_share"
         ],
-        "focus": "[color:DeepSkyBlue]点击分享按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击分享按钮</font>"
     },
     "try_share_to_wechat": {
         "recognition": "TemplateMatch",
@@ -185,7 +185,7 @@
             "share_back_to_natuto",
             "close_wechat_app"
         ],
-        "focus": "[color:DeepSkyBlue]微信分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">微信分享</font>"
     },
     "try_share_to_qq": {
         "recognition": "TemplateMatch",
@@ -206,7 +206,7 @@
             "share_back_to_natuto",
             "close_qq_app"
         ],
-        "focus": "[color:DeepSkyBlue]qq分享[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">qq分享</font>"
     },
     "share_back_to_natuto": {
         "enabled": false,
@@ -239,7 +239,7 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "[color:DeepSkyBlue]关闭微信[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭微信</font>"
     },
     "close_qq_app": {
         "pre_delay": 1000,
@@ -251,7 +251,7 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "[color:DeepSkyBlue]关闭qq[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭qq</font>"
     },
     "close_share_top_bar": {
         "recognition": "TemplateMatch",
@@ -277,7 +277,7 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "[color:DeepSkyBlue]关闭顶部栏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
     },
     "share_in_main_screen": {
         "recognition": "TemplateMatch",
@@ -321,7 +321,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:darkgray]关闭周榜更新下一步提示[/color]"
+        "focus": "<font color=\"darkgray\">关闭周榜更新下一步提示</font>"
     },
     "share_close_weekly_ninja_title": {
         "recognition": "TemplateMatch",
@@ -336,7 +336,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:darkgray]关闭周榜更新提示[/color]"
+        "focus": "<font color=\"darkgray\">关闭周榜更新提示</font>"
     },
     "share_start_in_main_screen": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Share.json
+++ b/assets/resource/base/pipeline/Share.json
@@ -8,13 +8,17 @@
             "share_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入分享任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入分享任务</font>"
+        }
     },
     "is_android_then_no_share": {
         "recognition": "Custom",
         "custom_recognition": "CheckIsAndroid",
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkorange\">不支持在安卓上进行分享，请使用模拟器！</font>"
+        }
     },
     "share_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -33,7 +37,9 @@
             "share_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "share_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -51,7 +57,9 @@
             "share_in_center_enter",
             "share_not_in_center_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        }
     },
     "share_ac_entry": {
         "recognition": "TemplateMatch",
@@ -74,7 +82,9 @@
             "share_not_in_center_enter",
             "share_ac_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        }
     },
     "share_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -104,7 +114,9 @@
             "share_ac_entry_undone",
             "[JumpBack]share_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">分享未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">分享未完成</font>"
+        }
     },
     "share_ac_done": {
         "recognition": "TemplateMatch",
@@ -120,7 +132,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">分享已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">分享已完成</font>"
+        }
     },
     "share_entry": {
         "recognition": "TemplateMatch",
@@ -144,7 +158,9 @@
         ],
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">尝试进入用户主页</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">尝试进入用户主页</font>"
+        }
     },
     "try_share": {
         "recognition": "TemplateMatch",
@@ -165,7 +181,9 @@
             "[JumpBack]share_close_weekly_ninja_title",
             "try_share"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击分享按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击分享按钮</font>"
+        }
     },
     "try_share_to_wechat": {
         "recognition": "TemplateMatch",
@@ -185,7 +203,9 @@
             "share_back_to_natuto",
             "close_wechat_app"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">微信分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">微信分享</font>"
+        }
     },
     "try_share_to_qq": {
         "recognition": "TemplateMatch",
@@ -206,7 +226,9 @@
             "share_back_to_natuto",
             "close_qq_app"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">qq分享</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">qq分享</font>"
+        }
     },
     "share_back_to_natuto": {
         "enabled": false,
@@ -239,7 +261,9 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭微信</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭微信</font>"
+        }
     },
     "close_qq_app": {
         "pre_delay": 1000,
@@ -251,7 +275,9 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭qq</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭qq</font>"
+        }
     },
     "close_share_top_bar": {
         "recognition": "TemplateMatch",
@@ -277,7 +303,9 @@
             "share_in_main_screen",
             "close_share_top_bar"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭顶部栏</font>"
+        }
     },
     "share_in_main_screen": {
         "recognition": "TemplateMatch",
@@ -321,7 +349,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">关闭周榜更新下一步提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">关闭周榜更新下一步提示</font>"
+        }
     },
     "share_close_weekly_ninja_title": {
         "recognition": "TemplateMatch",
@@ -336,7 +366,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">关闭周榜更新提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">关闭周榜更新提示</font>"
+        }
     },
     "share_start_in_main_screen": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/SharedNode.json
+++ b/assets/resource/base/pipeline/SharedNode.json
@@ -54,7 +54,7 @@
         "on_error": [
             "retry_failed"
         ],
-        "focus": "[color:darkgray]尝试返回主页面[/color]"
+        "focus": "<font color=\"darkgray\">尝试返回主页面</font>"
     },
     "group_notice": {
         "recognition": "Or",
@@ -100,7 +100,7 @@
         "post_wait_freezes": 500,
         "post_delay": 0,
         "next": "confirm_tip",
-        "focus": "[color:darkgray]离开当前队伍[/color]"
+        "focus": "<font color=\"darkgray\">离开当前队伍</font>"
     },
     "confirm_tip": {
         "recognition": "TemplateMatch",
@@ -206,7 +206,7 @@
         ],
         "template": "Startup/friend_rank.png",
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]关闭好友排名[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭好友排名</font>"
     },
     "close_chat": {
         "recognition": "TemplateMatch",
@@ -311,7 +311,7 @@
         ],
         "template": "SharedNode/center_entry_end.png",
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]当前任务已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">当前任务已完成</font>"
     },
     "weekly_sign": {
         "recognition": "TemplateMatch",
@@ -324,7 +324,7 @@
         "template": "SharedNode/weekly_sign.png",
         "action": "Click",
         "post_wait_freezes": 100,
-        "focus": "[color:DeepSkyBlue]进行周度签到[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进行周度签到</font>"
     },
     "im_come_back": {
         "recognition": "OCR",
@@ -340,7 +340,7 @@
         "next": [
             "im_come_back_award"
         ],
-        "focus": "[color:DeepSkyBlue]点击我回来了[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击我回来了</font>"
     },
     "im_come_back_award": {
         "recognition": "OCR",
@@ -352,7 +352,7 @@
         ],
         "expected": "领取礼物",
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]点击领取礼物[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击领取礼物</font>"
     },
     "text_notice": {
         "recognition": "Or",
@@ -482,7 +482,7 @@
         "template": "Naruto_club/close_club_button.png",
         "action": "Click",
         "post_delay": 1000,
-        "focus": "[color:DeepSkyBlue]关闭情报社[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
     },
     "debug_stop": {
         "action": "StopTask"
@@ -668,7 +668,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:darkgray]游戏等级提升[/color]"
+        "focus": "<font color=\"darkgray\">游戏等级提升</font>"
     },
     "ninja_guide_to_funtion_retry": {
         "recognition": "OCR",
@@ -686,7 +686,7 @@
     },
     "unknow_error": {
         "action": "StopTask",
-        "focus": "[color:tomato]未知原因导致卡死。[/color]"
+        "focus": "<font color=\"tomato\">未知原因导致卡死。</font>"
     },
     "retry_failed": {
         "pre_delay": 0,
@@ -695,7 +695,7 @@
             "try_back_main_screen",
             "back_main_screen_failed"
         ],
-        "focus": "[color:tomato]超过重试次数!返回主页并结束任务。[/color]"
+        "focus": "<font color=\"tomato\">超过重试次数!返回主页并结束任务。</font>"
     },
     "try_back_main_screen": {
         "max_hit": 1,
@@ -708,18 +708,18 @@
         "action": "Custom",
         "custom_action": "StopTaskList",
         "post_delay": 0,
-        "focus": "[color:tomato]尝试返回主界面失败!任务中断![/color]"
+        "focus": "<font color=\"tomato\">尝试返回主界面失败!任务中断!</font>"
     },
     "exit_naruto": {
         "action": "StopApp",
         "package": "com.tencent.KiHan",
-        "focus": "[color:DeepSkyBlue]关闭火影忍者手游APP[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭火影忍者手游APP</font>"
     },
     "battle_failed": {
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:tomato]战斗失败！[/color]",
+        "focus": "<font color=\"tomato\">战斗失败！</font>",
         "$doc": "如果不是要结束任务不要往这里走"
     },
     "ac_entry_mission_done": {
@@ -732,7 +732,7 @@
         ],
         "template": "SharedNode/center_entry_end.png",
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]任务已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">任务已完成</font>"
     },
     "ninja_guide_in_ninja_guide": {
         "recognition": "TemplateMatch",
@@ -751,7 +751,7 @@
             "up_swipe_for_ninja_guide_find_funtion_entry_end",
             "[JumpBack]up_swipe_for_ninja_guide_find_funtion_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入忍界指引[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入忍界指引</font>"
     },
     "up_swipe_for_ninja_guide_find_funtion_entry_end": {
         "recognition": "OCR",
@@ -867,7 +867,7 @@
             "ninja_guide_in_funtion_entry",
             "ninja_guide_find_funtion_entry"
         ],
-        "focus": "[color:DeepSkyBlue]找到功能入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
     },
     "ninja_guide_in_funtion_entry": {
         "recognition": "OCR",
@@ -886,7 +886,7 @@
             "ninja_guide_to_funtion_entry",
             "ninja_guide_to_funtion_entry_not_open"
         ],
-        "focus": "[color:DeepSkyBlue]选中功能入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
     },
     "ninja_guide_to_funtion_entry": {
         "recognition": "OCR",
@@ -919,7 +919,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]功能还没解锁[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
     },
     "ninja_guide_returning_player": {
         "recognition": "OCR",
@@ -938,7 +938,7 @@
             "ninja_guide_returning_player_to_ninja_guide",
             "ninja_guide_returning_player_in_ninja_guide"
         ],
-        "focus": "[color:DeepSkyBlue]进入回归版忍界指引[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入回归版忍界指引</font>"
     },
     "ninja_guide_returning_player_to_ninja_guide": {
         "recognition": "TemplateMatch",
@@ -1089,7 +1089,7 @@
             "ninja_guide_returning_player_in_funtion_entry",
             "ninja_guide_returning_player_find_funtion_entry"
         ],
-        "focus": "[color:DeepSkyBlue]找到功能入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
     },
     "ninja_guide_returning_player_in_funtion_entry": {
         "recognition": "OCR",
@@ -1108,7 +1108,7 @@
             "ninja_guide_returning_player_to_funtion_entry",
             "ninja_guide_returning_player_to_funtion_entry_not_open"
         ],
-        "focus": "[color:DeepSkyBlue]选中功能入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
     },
     "ninja_guide_returning_player_to_funtion_entry": {
         "recognition": "OCR",
@@ -1141,7 +1141,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]功能还没解锁[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
     },
     "game_resource_loading": {
         "recognition": "OCR",
@@ -1206,7 +1206,7 @@
             "incorrect_secondary_password",
             "secondary_password"
         ],
-        "focus": "[color:pink]开始输入二级密码[/color]"
+        "focus": "<font color=\"pink\">开始输入二级密码</font>"
     },
     "input_secondary_password": {
         "recognition": "OCR",
@@ -1260,7 +1260,7 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "[color:tomato]密码有误[/color]"
+        "focus": "<font color=\"tomato\">密码有误</font>"
     },
     "confirm_secondary_password": {
         "max_hit": 5,
@@ -1320,7 +1320,7 @@
             "without_pay_to_stronger_tip",
             "pay_to_stronger_tip"
         ],
-        "focus": "[color:pink]提升V等级提示[/color]"
+        "focus": "<font color=\"pink\">提升V等级提示</font>"
     },
     "without_pay_to_stronger_tip": {
         "recognition": "TemplateMatch",
@@ -1334,6 +1334,6 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:pink]提升V等级提示[/color]"
+        "focus": "<font color=\"pink\">提升V等级提示</font>"
     }
 }

--- a/assets/resource/base/pipeline/SharedNode.json
+++ b/assets/resource/base/pipeline/SharedNode.json
@@ -10,7 +10,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "任务已完成"
+        "focus": {
+            "Node.Action.Starting": "任务已完成"
+        }
     },
     "back_main_screen_and_stop": {
         "pre_delay": 0,
@@ -54,7 +56,9 @@
         "on_error": [
             "retry_failed"
         ],
-        "focus": "<font color=\"darkgray\">尝试返回主页面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">尝试返回主页面</font>"
+        }
     },
     "group_notice": {
         "recognition": "Or",
@@ -100,7 +104,9 @@
         "post_wait_freezes": 500,
         "post_delay": 0,
         "next": "confirm_tip",
-        "focus": "<font color=\"darkgray\">离开当前队伍</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">离开当前队伍</font>"
+        }
     },
     "confirm_tip": {
         "recognition": "TemplateMatch",
@@ -206,7 +212,9 @@
         ],
         "template": "Startup/friend_rank.png",
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">关闭好友排名</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭好友排名</font>"
+        }
     },
     "close_chat": {
         "recognition": "TemplateMatch",
@@ -311,7 +319,9 @@
         ],
         "template": "SharedNode/center_entry_end.png",
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">当前任务已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">当前任务已完成</font>"
+        }
     },
     "weekly_sign": {
         "recognition": "TemplateMatch",
@@ -324,7 +334,9 @@
         "template": "SharedNode/weekly_sign.png",
         "action": "Click",
         "post_wait_freezes": 100,
-        "focus": "<font color=\"DeepSkyBlue\">进行周度签到</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进行周度签到</font>"
+        }
     },
     "im_come_back": {
         "recognition": "OCR",
@@ -340,7 +352,9 @@
         "next": [
             "im_come_back_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击我回来了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击我回来了</font>"
+        }
     },
     "im_come_back_award": {
         "recognition": "OCR",
@@ -352,7 +366,9 @@
         ],
         "expected": "领取礼物",
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">点击领取礼物</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击领取礼物</font>"
+        }
     },
     "text_notice": {
         "recognition": "Or",
@@ -482,7 +498,9 @@
         "template": "Naruto_club/close_club_button.png",
         "action": "Click",
         "post_delay": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭情报社</font>"
+        }
     },
     "debug_stop": {
         "action": "StopTask"
@@ -505,7 +523,9 @@
             "[JumpBack]this_week_nintou_title",
             "[JumpBack]this_week_fighting_title"
         ],
-        "focus": "获得称号"
+        "focus": {
+            "Node.Action.Starting": "获得称号"
+        }
     },
     "this_week_nintou_title": {
         "recognition": "OCR",
@@ -520,7 +540,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "获得忍道称号"
+        "focus": {
+            "Node.Action.Starting": "获得忍道称号"
+        }
     },
     "this_week_fighting_title": {
         "recognition": "OCR",
@@ -535,7 +557,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "获得格斗称号"
+        "focus": {
+            "Node.Action.Starting": "获得格斗称号"
+        }
     },
     "close_notice": {
         "recognition": {
@@ -561,7 +585,9 @@
             "back_main_screen"
         ],
         "on_error": "check_main_screen",
-        "focus": "关闭气泡弹窗"
+        "focus": {
+            "Node.Action.Starting": "关闭气泡弹窗"
+        }
     },
     "ensure_to_close": {
         "recognition": {
@@ -668,7 +694,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">游戏等级提升</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">游戏等级提升</font>"
+        }
     },
     "ninja_guide_to_funtion_retry": {
         "recognition": "OCR",
@@ -686,7 +714,9 @@
     },
     "unknow_error": {
         "action": "StopTask",
-        "focus": "<font color=\"tomato\">未知原因导致卡死。</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">未知原因导致卡死。</font>"
+        }
     },
     "retry_failed": {
         "pre_delay": 0,
@@ -695,7 +725,9 @@
             "try_back_main_screen",
             "back_main_screen_failed"
         ],
-        "focus": "<font color=\"tomato\">超过重试次数!返回主页并结束任务。</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">超过重试次数!返回主页并结束任务。</font>"
+        }
     },
     "try_back_main_screen": {
         "max_hit": 1,
@@ -708,18 +740,24 @@
         "action": "Custom",
         "custom_action": "StopTaskList",
         "post_delay": 0,
-        "focus": "<font color=\"tomato\">尝试返回主界面失败!任务中断!</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">尝试返回主界面失败!任务中断!</font>"
+        }
     },
     "exit_naruto": {
         "action": "StopApp",
         "package": "com.tencent.KiHan",
-        "focus": "<font color=\"DeepSkyBlue\">关闭火影忍者手游APP</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭火影忍者手游APP</font>"
+        }
     },
     "battle_failed": {
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"tomato\">战斗失败！</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">战斗失败！</font>"
+        },
         "$doc": "如果不是要结束任务不要往这里走"
     },
     "ac_entry_mission_done": {
@@ -732,7 +770,9 @@
         ],
         "template": "SharedNode/center_entry_end.png",
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">任务已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">任务已完成</font>"
+        }
     },
     "ninja_guide_in_ninja_guide": {
         "recognition": "TemplateMatch",
@@ -751,7 +791,9 @@
             "up_swipe_for_ninja_guide_find_funtion_entry_end",
             "[JumpBack]up_swipe_for_ninja_guide_find_funtion_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入忍界指引</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍界指引</font>"
+        }
     },
     "up_swipe_for_ninja_guide_find_funtion_entry_end": {
         "recognition": "OCR",
@@ -867,7 +909,9 @@
             "ninja_guide_in_funtion_entry",
             "ninja_guide_find_funtion_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
+        }
     },
     "ninja_guide_in_funtion_entry": {
         "recognition": "OCR",
@@ -886,7 +930,9 @@
             "ninja_guide_to_funtion_entry",
             "ninja_guide_to_funtion_entry_not_open"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
+        }
     },
     "ninja_guide_to_funtion_entry": {
         "recognition": "OCR",
@@ -919,7 +965,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
+        }
     },
     "ninja_guide_returning_player": {
         "recognition": "OCR",
@@ -938,7 +986,9 @@
             "ninja_guide_returning_player_to_ninja_guide",
             "ninja_guide_returning_player_in_ninja_guide"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入回归版忍界指引</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入回归版忍界指引</font>"
+        }
     },
     "ninja_guide_returning_player_to_ninja_guide": {
         "recognition": "TemplateMatch",
@@ -1089,7 +1139,9 @@
             "ninja_guide_returning_player_in_funtion_entry",
             "ninja_guide_returning_player_find_funtion_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到功能入口</font>"
+        }
     },
     "ninja_guide_returning_player_in_funtion_entry": {
         "recognition": "OCR",
@@ -1108,7 +1160,9 @@
             "ninja_guide_returning_player_to_funtion_entry",
             "ninja_guide_returning_player_to_funtion_entry_not_open"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中功能入口</font>"
+        }
     },
     "ninja_guide_returning_player_to_funtion_entry": {
         "recognition": "OCR",
@@ -1141,7 +1195,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">功能还没解锁</font>"
+        }
     },
     "game_resource_loading": {
         "recognition": "OCR",
@@ -1206,7 +1262,9 @@
             "incorrect_secondary_password",
             "secondary_password"
         ],
-        "focus": "<font color=\"pink\">开始输入二级密码</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">开始输入二级密码</font>"
+        }
     },
     "input_secondary_password": {
         "recognition": "OCR",
@@ -1260,7 +1318,9 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "<font color=\"tomato\">密码有误</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">密码有误</font>"
+        }
     },
     "confirm_secondary_password": {
         "max_hit": 5,
@@ -1320,7 +1380,9 @@
             "without_pay_to_stronger_tip",
             "pay_to_stronger_tip"
         ],
-        "focus": "<font color=\"pink\">提升V等级提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">提升V等级提示</font>"
+        }
     },
     "without_pay_to_stronger_tip": {
         "recognition": "TemplateMatch",
@@ -1334,6 +1396,8 @@
         "inverse": true,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"pink\">提升V等级提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">提升V等级提示</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Shop.json
+++ b/assets/resource/base/pipeline/Shop.json
@@ -7,7 +7,9 @@
             "shop_in_root_shop",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入商店任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入商店任务</font>"
+        }
     },
     "shop_entry": {
         "recognition": "TemplateMatch",
@@ -211,7 +213,9 @@
             "shop_in_exchange_jade",
             "shop_exchange_jade"
         ],
-        "focus": "<font color=\"pink\">进入玉石兑换</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">进入玉石兑换</font>"
+        }
     },
     "shop_without_exchange_jade": {
         "recognition": "OCR",
@@ -305,7 +309,9 @@
             "shop_jade_child_shop_slot_2",
             "shop_jade_shop_done"
         ],
-        "focus": "<font color=\"pink\">玉石兑换完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">玉石兑换完成</font>"
+        }
     },
     "shop_exchange_jade_not_check_S": {
         "enabled": false,
@@ -898,7 +904,9 @@
             "shop_to_play_methon_parent_shop",
             "shop_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">玉石商店任务完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">玉石商店任务完成</font>"
+        }
     },
     "shop_to_play_methon_parent_shop": {
         "enabled": false,
@@ -1379,7 +1387,9 @@
             "shop_to_group_child_shop",
             "shop_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存商店任务完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存商店任务完成</font>"
+        }
     },
     "shop_to_point_race_child_shop": {
         "enabled": false,
@@ -1799,7 +1809,9 @@
             "shop_to_group_child_shop",
             "shop_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">积分赛商店任务完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">积分赛商店任务完成</font>"
+        }
     },
     "shop_to_group_child_shop": {
         "enabled": false,
@@ -2293,7 +2305,9 @@
         "next": [
             "shop_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织商店任务完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织商店任务完成</font>"
+        }
     },
     "shop_done": {
         "recognition": "TemplateMatch",
@@ -2309,6 +2323,8 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">商店任务完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">商店任务完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Shop.json
+++ b/assets/resource/base/pipeline/Shop.json
@@ -7,7 +7,7 @@
             "shop_in_root_shop",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入商店任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入商店任务</font>"
     },
     "shop_entry": {
         "recognition": "TemplateMatch",
@@ -211,7 +211,7 @@
             "shop_in_exchange_jade",
             "shop_exchange_jade"
         ],
-        "focus": "[color:pink]进入玉石兑换[/color]"
+        "focus": "<font color=\"pink\">进入玉石兑换</font>"
     },
     "shop_without_exchange_jade": {
         "recognition": "OCR",
@@ -305,7 +305,7 @@
             "shop_jade_child_shop_slot_2",
             "shop_jade_shop_done"
         ],
-        "focus": "[color:pink]玉石兑换完成[/color]"
+        "focus": "<font color=\"pink\">玉石兑换完成</font>"
     },
     "shop_exchange_jade_not_check_S": {
         "enabled": false,
@@ -898,7 +898,7 @@
             "shop_to_play_methon_parent_shop",
             "shop_done"
         ],
-        "focus": "[color:DeepSkyBlue]玉石商店任务完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">玉石商店任务完成</font>"
     },
     "shop_to_play_methon_parent_shop": {
         "enabled": false,
@@ -1379,7 +1379,7 @@
             "shop_to_group_child_shop",
             "shop_done"
         ],
-        "focus": "[color:DeepSkyBlue]生存商店任务完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存商店任务完成</font>"
     },
     "shop_to_point_race_child_shop": {
         "enabled": false,
@@ -1799,7 +1799,7 @@
             "shop_to_group_child_shop",
             "shop_done"
         ],
-        "focus": "[color:DeepSkyBlue]积分赛商店任务完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">积分赛商店任务完成</font>"
     },
     "shop_to_group_child_shop": {
         "enabled": false,
@@ -2293,7 +2293,7 @@
         "next": [
             "shop_done"
         ],
-        "focus": "[color:DeepSkyBlue]组织商店任务完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织商店任务完成</font>"
     },
     "shop_done": {
         "recognition": "TemplateMatch",
@@ -2309,6 +2309,6 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]商店任务完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">商店任务完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/Sky_ground.json
+++ b/assets/resource/base/pipeline/Sky_ground.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入天地任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入天地任务</font>"
+        }
     },
     "sky_ground_entry": {
         "recognition": "Or",
@@ -52,7 +54,9 @@
             "no_group",
             "sky_ground_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        }
     },
     "sky_ground_gameplay": {
         "recognition": "TemplateMatch",
@@ -85,7 +89,9 @@
             "sky_ground_mode",
             "[JumpBack]swipe_for_sky_ground_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        }
     },
     "sky_ground_mode": {
         "recognition": "TemplateMatch",
@@ -109,7 +115,9 @@
             "[JumpBack]sky_ground_mode",
             "group_mode_not_open"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入天地模式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入天地模式</font>"
+        }
     },
     "group_mode_not_open": {
         "recognition": "OCR",
@@ -144,7 +152,9 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "<font color=\"DeepSkyBlue\">寻找天地模式</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找天地模式</font>"
+        }
     },
     "sky_ground_battlefield_selection": {
         "recognition": "OCR",
@@ -166,7 +176,9 @@
             "ground_battlefield",
             "sky_ground_settlement"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择战场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择战场</font>"
+        }
     },
     "sky_ground_settlement": {
         "recognition": "OCR",
@@ -183,7 +195,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">天地战场结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">天地战场结束</font>"
+        }
     },
     "sky_ground_not_open": {
         "recognition": "OCR",
@@ -200,7 +214,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">天地战场未开始</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">天地战场未开始</font>"
+        }
     },
     "sky_battlefield": {
         "recognition": "TemplateMatch",
@@ -219,7 +235,9 @@
             "sky_ground_to_column",
             "[JumpBack]sky_battlefield"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择天战场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择天战场</font>"
+        }
     },
     "ground_battlefield": {
         "recognition": "TemplateMatch",
@@ -237,7 +255,9 @@
             "sky_ground_confirm_set",
             "[JumpBack]ground_battlefield"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择地战场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择地战场</font>"
+        }
     },
     "sky_ground_confirm_battlefield_selection": {
         "recognition": "OCR",
@@ -257,7 +277,9 @@
             "sky_ground_select_ninja",
             "[JumpBack]sky_ground_confirm_battlefield_selection"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认战场选择</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认战场选择</font>"
+        }
     },
     "sky_ground_select_ninja": {
         "recognition": "TemplateMatch",
@@ -274,7 +296,9 @@
             "sky_ground_selected_ninja",
             "[JumpBack]sky_ground_select_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择忍者</font>"
+        }
     },
     "sky_ground_recommended_ninja": {
         "recognition": "TemplateMatch",
@@ -291,7 +315,9 @@
             "sky_ground_selected_ninja",
             "[JumpBack]sky_ground_recommended_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择推荐忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择推荐忍者</font>"
+        }
     },
     "sky_ground_selected_ninja": {
         "recognition": "TemplateMatch",
@@ -308,7 +334,9 @@
             "sky_ground_to_select_summon",
             "sky_ground_in_select_summon"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中忍者</font>"
+        }
     },
     "sky_ground_to_select_summon": {
         "recognition": "TemplateMatch",
@@ -324,7 +352,9 @@
             "sky_ground_in_select_summon",
             "[JumpBack]sky_ground_to_select_summon"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择通灵</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择通灵</font>"
+        }
     },
     "sky_ground_in_select_summon": {
         "recognition": "TemplateMatch",
@@ -339,7 +369,9 @@
             "sky_ground_summon_done",
             "[JumpBack]sky_ground_select_summon"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始选择通灵</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始选择通灵</font>"
+        }
     },
     "sky_ground_select_summon": {
         "recognition": "TemplateMatch",
@@ -353,7 +385,9 @@
             "battle/通灵"
         ],
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">识别通灵</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">识别通灵</font>"
+        }
     },
     "sky_ground_summon_done": {
         "recognition": "OCR",
@@ -369,7 +403,9 @@
             "sky_ground_to_select_roll",
             "sky_ground_in_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">完成选择通灵</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">完成选择通灵</font>"
+        }
     },
     "sky_ground_to_select_roll": {
         "recognition": "TemplateMatch",
@@ -385,7 +421,9 @@
             "sky_ground_in_select_roll",
             "[JumpBack]sky_ground_to_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
+        }
     },
     "sky_ground_in_select_roll": {
         "recognition": "TemplateMatch",
@@ -393,7 +431,9 @@
         "next": [
             "sky_ground_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
+        }
     },
     "sky_ground_select_roll": {
         "recognition": "TemplateMatch",
@@ -411,7 +451,9 @@
             "sky_ground_selected_roll",
             "sky_ground_select_roll"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">识别密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">识别密卷</font>"
+        }
     },
     "sky_ground_selected_roll": {
         "recognition": "OCR",
@@ -426,7 +468,9 @@
         "next": [
             "sky_ground_confirm_set"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
+        }
     },
     "sky_ground_confirm_set": {
         "recognition": "OCR",
@@ -448,7 +492,9 @@
             "left_swipe_for_empty_column",
             "up_swipe_for_empty_column"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认配置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认配置</font>"
+        }
     },
     "sky_ground_group_encouragement": {
         "recognition": "OCR",
@@ -468,7 +514,9 @@
             "left_swipe_for_empty_column",
             "up_swipe_for_empty_column"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织激励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织激励</font>"
+        }
     },
     "sky_ground_to_column": {
         "recognition": "TemplateMatch",
@@ -495,7 +543,9 @@
             "down_swipe_for_empty_column",
             "sky_ground_in_main"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">前往空柱子</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往空柱子</font>"
+        }
     },
     "sky_ground_to_award_column": {
         "recognition": "TemplateMatch",
@@ -583,7 +633,9 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">右滑选择空柱子</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">右滑选择空柱子</font>"
+        }
     },
     "left_swipe_for_empty_column": {
         "max_hit": 1,
@@ -621,7 +673,9 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">左滑选择空柱子</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">左滑选择空柱子</font>"
+        }
     },
     "down_swipe_for_empty_column": {
         "max_hit": 1,
@@ -659,7 +713,9 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">下滑选择空柱子</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">下滑选择空柱子</font>"
+        }
     },
     "up_swipe_for_empty_column": {
         "max_hit": 1,
@@ -697,7 +753,9 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">上滑选择空柱子</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">上滑选择空柱子</font>"
+        }
     },
     "sky_ground_get_bead": {
         "recognition": "TemplateMatch",
@@ -706,7 +764,9 @@
             0.9
         ],
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">抢经验球</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">抢经验球</font>"
+        }
     },
     "sky_ground_check_no_bead": {
         "recognition": "TemplateMatch",
@@ -715,7 +775,9 @@
             0.9
         ],
         "inverse": true,
-        "focus": "<font color=\"DeepSkyBlue\">确认没有经验求</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认没有经验求</font>"
+        }
     },
     "sky_ground_in_main": {
         "recognition": "TemplateMatch",
@@ -779,7 +841,9 @@
             "sky_ground_in_main",
             "win_to_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
+        }
     },
     "sky_ground_fail": {
         "recognition": "TemplateMatch",
@@ -798,7 +862,9 @@
             "sky_ground_confirm_new_set",
             "[JumpBack]sky_ground_fail"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗失败</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗失败</font>"
+        }
     },
     "sky_ground_confirm_new_set": {
         "recognition": "OCR",
@@ -817,7 +883,9 @@
             "sky_ground_in_main",
             "[JumpBack]sky_ground_confirm_new_set"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认配置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认配置</font>"
+        }
     },
     "sky_ground_end": {
         "recognition": "OCR",
@@ -851,7 +919,9 @@
             "sky_ground_end_confirm_back_main_screen",
             "[JumpBack]sky_ground_end_back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">天地开始回主页面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">天地开始回主页面</font>"
+        }
     },
     "sky_ground_end_confirm_back_main_screen": {
         "recognition": "OCR",
@@ -870,7 +940,9 @@
             "sky_ground_end_not_in_main",
             "[JumpBack]sky_ground_end_confirm_back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">天地确认回主页面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">天地确认回主页面</font>"
+        }
     },
     "sky_ground_end_not_in_main": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Sky_ground.json
+++ b/assets/resource/base/pipeline/Sky_ground.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入天地任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入天地任务</font>"
     },
     "sky_ground_entry": {
         "recognition": "Or",
@@ -52,7 +52,7 @@
             "no_group",
             "sky_ground_entry"
         ],
-        "focus": "[color:DeepSkyBlue]组织主界面入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
     },
     "sky_ground_gameplay": {
         "recognition": "TemplateMatch",
@@ -85,7 +85,7 @@
             "sky_ground_mode",
             "[JumpBack]swipe_for_sky_ground_mode"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中组织玩法按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
     },
     "sky_ground_mode": {
         "recognition": "TemplateMatch",
@@ -109,7 +109,7 @@
             "[JumpBack]sky_ground_mode",
             "group_mode_not_open"
         ],
-        "focus": "[color:DeepSkyBlue]进入天地模式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入天地模式</font>"
     },
     "group_mode_not_open": {
         "recognition": "OCR",
@@ -144,7 +144,7 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "[color:DeepSkyBlue]寻找天地模式[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找天地模式</font>"
     },
     "sky_ground_battlefield_selection": {
         "recognition": "OCR",
@@ -166,7 +166,7 @@
             "ground_battlefield",
             "sky_ground_settlement"
         ],
-        "focus": "[color:DeepSkyBlue]选择战场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择战场</font>"
     },
     "sky_ground_settlement": {
         "recognition": "OCR",
@@ -183,7 +183,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]天地战场结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">天地战场结束</font>"
     },
     "sky_ground_not_open": {
         "recognition": "OCR",
@@ -200,7 +200,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]天地战场未开始[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">天地战场未开始</font>"
     },
     "sky_battlefield": {
         "recognition": "TemplateMatch",
@@ -219,7 +219,7 @@
             "sky_ground_to_column",
             "[JumpBack]sky_battlefield"
         ],
-        "focus": "[color:DeepSkyBlue]选择天战场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择天战场</font>"
     },
     "ground_battlefield": {
         "recognition": "TemplateMatch",
@@ -237,7 +237,7 @@
             "sky_ground_confirm_set",
             "[JumpBack]ground_battlefield"
         ],
-        "focus": "[color:DeepSkyBlue]选择地战场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择地战场</font>"
     },
     "sky_ground_confirm_battlefield_selection": {
         "recognition": "OCR",
@@ -257,7 +257,7 @@
             "sky_ground_select_ninja",
             "[JumpBack]sky_ground_confirm_battlefield_selection"
         ],
-        "focus": "[color:DeepSkyBlue]确认战场选择[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认战场选择</font>"
     },
     "sky_ground_select_ninja": {
         "recognition": "TemplateMatch",
@@ -274,7 +274,7 @@
             "sky_ground_selected_ninja",
             "[JumpBack]sky_ground_select_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]选择忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择忍者</font>"
     },
     "sky_ground_recommended_ninja": {
         "recognition": "TemplateMatch",
@@ -291,7 +291,7 @@
             "sky_ground_selected_ninja",
             "[JumpBack]sky_ground_recommended_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]选择推荐忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择推荐忍者</font>"
     },
     "sky_ground_selected_ninja": {
         "recognition": "TemplateMatch",
@@ -308,7 +308,7 @@
             "sky_ground_to_select_summon",
             "sky_ground_in_select_summon"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中忍者</font>"
     },
     "sky_ground_to_select_summon": {
         "recognition": "TemplateMatch",
@@ -324,7 +324,7 @@
             "sky_ground_in_select_summon",
             "[JumpBack]sky_ground_to_select_summon"
         ],
-        "focus": "[color:DeepSkyBlue]选择通灵[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择通灵</font>"
     },
     "sky_ground_in_select_summon": {
         "recognition": "TemplateMatch",
@@ -339,7 +339,7 @@
             "sky_ground_summon_done",
             "[JumpBack]sky_ground_select_summon"
         ],
-        "focus": "[color:DeepSkyBlue]开始选择通灵[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始选择通灵</font>"
     },
     "sky_ground_select_summon": {
         "recognition": "TemplateMatch",
@@ -353,7 +353,7 @@
             "battle/通灵"
         ],
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]识别通灵[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">识别通灵</font>"
     },
     "sky_ground_summon_done": {
         "recognition": "OCR",
@@ -369,7 +369,7 @@
             "sky_ground_to_select_roll",
             "sky_ground_in_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]完成选择通灵[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">完成选择通灵</font>"
     },
     "sky_ground_to_select_roll": {
         "recognition": "TemplateMatch",
@@ -385,7 +385,7 @@
             "sky_ground_in_select_roll",
             "[JumpBack]sky_ground_to_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]选择秘卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择秘卷</font>"
     },
     "sky_ground_in_select_roll": {
         "recognition": "TemplateMatch",
@@ -393,7 +393,7 @@
         "next": [
             "sky_ground_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]开始选择密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始选择密卷</font>"
     },
     "sky_ground_select_roll": {
         "recognition": "TemplateMatch",
@@ -411,7 +411,7 @@
             "sky_ground_selected_roll",
             "sky_ground_select_roll"
         ],
-        "focus": "[color:DeepSkyBlue]识别密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">识别密卷</font>"
     },
     "sky_ground_selected_roll": {
         "recognition": "OCR",
@@ -426,7 +426,7 @@
         "next": [
             "sky_ground_confirm_set"
         ],
-        "focus": "[color:DeepSkyBlue]完成选择密卷[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">完成选择密卷</font>"
     },
     "sky_ground_confirm_set": {
         "recognition": "OCR",
@@ -448,7 +448,7 @@
             "left_swipe_for_empty_column",
             "up_swipe_for_empty_column"
         ],
-        "focus": "[color:DeepSkyBlue]确认配置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认配置</font>"
     },
     "sky_ground_group_encouragement": {
         "recognition": "OCR",
@@ -468,7 +468,7 @@
             "left_swipe_for_empty_column",
             "up_swipe_for_empty_column"
         ],
-        "focus": "[color:DeepSkyBlue]组织激励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织激励</font>"
     },
     "sky_ground_to_column": {
         "recognition": "TemplateMatch",
@@ -495,7 +495,7 @@
             "down_swipe_for_empty_column",
             "sky_ground_in_main"
         ],
-        "focus": "[color:DeepSkyBlue]前往空柱子[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往空柱子</font>"
     },
     "sky_ground_to_award_column": {
         "recognition": "TemplateMatch",
@@ -583,7 +583,7 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "[color:DeepSkyBlue]右滑选择空柱子[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">右滑选择空柱子</font>"
     },
     "left_swipe_for_empty_column": {
         "max_hit": 1,
@@ -621,7 +621,7 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "[color:DeepSkyBlue]左滑选择空柱子[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">左滑选择空柱子</font>"
     },
     "down_swipe_for_empty_column": {
         "max_hit": 1,
@@ -659,7 +659,7 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "[color:DeepSkyBlue]下滑选择空柱子[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">下滑选择空柱子</font>"
     },
     "up_swipe_for_empty_column": {
         "max_hit": 1,
@@ -697,7 +697,7 @@
             "[JumpBack]sky_ground_in_fight",
             "sky_ground_in_main"
         ],
-        "focus": "[color:DeepSkyBlue]上滑选择空柱子[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">上滑选择空柱子</font>"
     },
     "sky_ground_get_bead": {
         "recognition": "TemplateMatch",
@@ -706,7 +706,7 @@
             0.9
         ],
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]抢经验球[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">抢经验球</font>"
     },
     "sky_ground_check_no_bead": {
         "recognition": "TemplateMatch",
@@ -715,7 +715,7 @@
             0.9
         ],
         "inverse": true,
-        "focus": "[color:DeepSkyBlue]确认没有经验求[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认没有经验求</font>"
     },
     "sky_ground_in_main": {
         "recognition": "TemplateMatch",
@@ -779,7 +779,7 @@
             "sky_ground_in_main",
             "win_to_entry"
         ],
-        "focus": "[color:DeepSkyBlue]战斗胜利[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
     },
     "sky_ground_fail": {
         "recognition": "TemplateMatch",
@@ -798,7 +798,7 @@
             "sky_ground_confirm_new_set",
             "[JumpBack]sky_ground_fail"
         ],
-        "focus": "[color:DeepSkyBlue]战斗失败[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗失败</font>"
     },
     "sky_ground_confirm_new_set": {
         "recognition": "OCR",
@@ -817,7 +817,7 @@
             "sky_ground_in_main",
             "[JumpBack]sky_ground_confirm_new_set"
         ],
-        "focus": "[color:DeepSkyBlue]确认配置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认配置</font>"
     },
     "sky_ground_end": {
         "recognition": "OCR",
@@ -851,7 +851,7 @@
             "sky_ground_end_confirm_back_main_screen",
             "[JumpBack]sky_ground_end_back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]天地开始回主页面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">天地开始回主页面</font>"
     },
     "sky_ground_end_confirm_back_main_screen": {
         "recognition": "OCR",
@@ -870,7 +870,7 @@
             "sky_ground_end_not_in_main",
             "[JumpBack]sky_ground_end_confirm_back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]天地确认回主页面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">天地确认回主页面</font>"
     },
     "sky_ground_end_not_in_main": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Spring_festival_post_office.json
+++ b/assets/resource/base/pipeline/Spring_festival_post_office.json
@@ -8,7 +8,9 @@
             "spring_festival_post_office_event_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入新春邮局任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入新春邮局任务</font>"
+        }
     },
     "spring_festival_post_office_event_done": {
         "recognition": "TemplateMatch",
@@ -22,7 +24,9 @@
         "green_mask": true,
         "threshold": 0.9,
         "action": "StopTask",
-        "focus": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
+        }
     },
     "spring_festival_post_office_event_enter": {
         "recognition": "TemplateMatch",
@@ -60,7 +64,9 @@
             "spring_festival_post_office_enter",
             "spring_festival_post_office_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入贺新春主界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入贺新春主界面</font>"
+        }
     },
     "spring_festival_post_office_done": {
         "recognition": "TemplateMatch",
@@ -76,7 +82,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
+        }
     },
     "spring_festival_post_office_enter": {
         "recognition": "TemplateMatch",
@@ -597,7 +605,9 @@
             "spring_festival_post_office_card_pack",
             "spring_festival_post_office_gacha"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">新春邮局抽卡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">新春邮局抽卡</font>"
+        }
     },
     "spring_festival_post_office_gacha_done": {
         "recognition": "TemplateMatch",
@@ -616,7 +626,9 @@
             "spring_festival_post_office_back_in_post_office_1",
             "spring_festival_post_office_back_to_post_office_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">新春邮局抽卡已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">新春邮局抽卡已完成</font>"
+        }
     },
     "spring_festival_post_office_card_pack": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Spring_festival_post_office.json
+++ b/assets/resource/base/pipeline/Spring_festival_post_office.json
@@ -8,7 +8,7 @@
             "spring_festival_post_office_event_done",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入新春邮局任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入新春邮局任务</font>"
     },
     "spring_festival_post_office_event_done": {
         "recognition": "TemplateMatch",
@@ -22,7 +22,7 @@
         "green_mask": true,
         "threshold": 0.9,
         "action": "StopTask",
-        "focus": "[color:DeepSkyBlue]新春邮局已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
     },
     "spring_festival_post_office_event_enter": {
         "recognition": "TemplateMatch",
@@ -60,7 +60,7 @@
             "spring_festival_post_office_enter",
             "spring_festival_post_office_done"
         ],
-        "focus": "[color:DeepSkyBlue]进入贺新春主界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入贺新春主界面</font>"
     },
     "spring_festival_post_office_done": {
         "recognition": "TemplateMatch",
@@ -76,7 +76,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]新春邮局已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">新春邮局已完成</font>"
     },
     "spring_festival_post_office_enter": {
         "recognition": "TemplateMatch",
@@ -597,7 +597,7 @@
             "spring_festival_post_office_card_pack",
             "spring_festival_post_office_gacha"
         ],
-        "focus": "[color:DeepSkyBlue]新春邮局抽卡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">新春邮局抽卡</font>"
     },
     "spring_festival_post_office_gacha_done": {
         "recognition": "TemplateMatch",
@@ -616,7 +616,7 @@
             "spring_festival_post_office_back_in_post_office_1",
             "spring_festival_post_office_back_to_post_office_1"
         ],
-        "focus": "[color:DeepSkyBlue]新春邮局抽卡已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">新春邮局抽卡已完成</font>"
     },
     "spring_festival_post_office_card_pack": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Startup.json
+++ b/assets/resource/base/pipeline/Startup.json
@@ -8,7 +8,9 @@
         "next": [
             "start_naruto"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">火影忍者，启动！</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">火影忍者，启动！</font>"
+        }
     },
     "start_naruto": {
         "timeout": 30000,
@@ -27,7 +29,9 @@
         "next": [
             "start_up"
         ],
-        "focus": "<font color=\"tomato\">重启火影</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">重启火影</font>"
+        }
     },
     "splash_screen": {
         "recognition": "OCR",
@@ -89,7 +93,9 @@
         "pre_wait_freezes": 500,
         "pre_delay": 0,
         "action": "Click",
-        "focus": "<font color=\"DeepSkyBlue\">尝试关闭青少年界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">尝试关闭青少年界面</font>"
+        }
     },
     "close_before_game_notice": {
         "recognition": "TemplateMatch",
@@ -102,7 +108,9 @@
         "template": "Startup/x.png",
         "action": "Click",
         "post_delay": 500,
-        "focus": "<font color=\"DeepSkyBlue\">关闭游戏前公告</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭游戏前公告</font>"
+        }
     },
     "agree_log_in": {
         "recognition": "OCR",
@@ -122,7 +130,9 @@
             "empty_number",
             "agree_log_in"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认登录</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认登录</font>"
+        }
     },
     "without_agree_log_in": {
         "recognition": "OCR",
@@ -142,7 +152,9 @@
         "expected": "位数不足",
         "action": "Custom",
         "custom_action": "StopTaskList",
-        "focus": "<font color=\"tomato\">当前没有可登录的账号</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">当前没有可登录的账号</font>"
+        }
     },
     "agree_info": {
         "recognition": "OCR",
@@ -156,7 +168,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 1500,
-        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        }
     },
     "refuse_info": {
         "recognition": "OCR",
@@ -176,7 +190,9 @@
             "refuse_info",
             "click_start_game"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        }
     },
     "confirm_refuse_info": {
         "recognition": "OCR",
@@ -189,7 +205,9 @@
         "expected": "确定",
         "action": "Click",
         "post_delay": 1000,
-        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
+        }
     },
     "click_start_game": {
         "recognition": "TemplateMatch",
@@ -209,7 +227,9 @@
             "click_start_game",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击开始游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击开始游戏</font>"
+        }
     },
     "before_game_loading_1": {
         "recognition": "TemplateMatch",
@@ -257,7 +277,9 @@
             "[JumpBack]without_before_game_black_screen",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">加载结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">加载结束</font>"
+        }
     },
     "without_before_game_black_screen": {
         "max_hit": 10,
@@ -391,6 +413,8 @@
         "template": "SharedNode/android_qq_login.png",
         "pre_delay": 0,
         "post_delay": 300,
-        "focus": "<font color=\"tomato\">由于最终用户协议(EULA),你必须手动同意协议</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">由于最终用户协议(EULA),你必须手动同意协议</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Startup.json
+++ b/assets/resource/base/pipeline/Startup.json
@@ -8,7 +8,7 @@
         "next": [
             "start_naruto"
         ],
-        "focus": "[color:DeepSkyBlue]火影忍者，启动！[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">火影忍者，启动！</font>"
     },
     "start_naruto": {
         "timeout": 30000,
@@ -27,7 +27,7 @@
         "next": [
             "start_up"
         ],
-        "focus": "[color:tomato]重启火影[/color]"
+        "focus": "<font color=\"tomato\">重启火影</font>"
     },
     "splash_screen": {
         "recognition": "OCR",
@@ -89,7 +89,7 @@
         "pre_wait_freezes": 500,
         "pre_delay": 0,
         "action": "Click",
-        "focus": "[color:DeepSkyBlue]尝试关闭青少年界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">尝试关闭青少年界面</font>"
     },
     "close_before_game_notice": {
         "recognition": "TemplateMatch",
@@ -102,7 +102,7 @@
         "template": "Startup/x.png",
         "action": "Click",
         "post_delay": 500,
-        "focus": "[color:DeepSkyBlue]关闭游戏前公告[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭游戏前公告</font>"
     },
     "agree_log_in": {
         "recognition": "OCR",
@@ -122,7 +122,7 @@
             "empty_number",
             "agree_log_in"
         ],
-        "focus": "[color:DeepSkyBlue]确认登录[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认登录</font>"
     },
     "without_agree_log_in": {
         "recognition": "OCR",
@@ -142,7 +142,7 @@
         "expected": "位数不足",
         "action": "Custom",
         "custom_action": "StopTaskList",
-        "focus": "[color:tomato]当前没有可登录的账号[/color]"
+        "focus": "<font color=\"tomato\">当前没有可登录的账号</font>"
     },
     "agree_info": {
         "recognition": "OCR",
@@ -156,7 +156,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 1500,
-        "focus": "[color:DeepSkyBlue]确认同意信息[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
     },
     "refuse_info": {
         "recognition": "OCR",
@@ -176,7 +176,7 @@
             "refuse_info",
             "click_start_game"
         ],
-        "focus": "[color:DeepSkyBlue]确认同意信息[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
     },
     "confirm_refuse_info": {
         "recognition": "OCR",
@@ -189,7 +189,7 @@
         "expected": "确定",
         "action": "Click",
         "post_delay": 1000,
-        "focus": "[color:DeepSkyBlue]确认同意信息[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认同意信息</font>"
     },
     "click_start_game": {
         "recognition": "TemplateMatch",
@@ -209,7 +209,7 @@
             "click_start_game",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]点击开始游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击开始游戏</font>"
     },
     "before_game_loading_1": {
         "recognition": "TemplateMatch",
@@ -257,7 +257,7 @@
             "[JumpBack]without_before_game_black_screen",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]加载结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">加载结束</font>"
     },
     "without_before_game_black_screen": {
         "max_hit": 10,
@@ -391,6 +391,6 @@
         "template": "SharedNode/android_qq_login.png",
         "pre_delay": 0,
         "post_delay": 300,
-        "focus": "[color:tomato]由于最终用户协议(EULA),你必须手动同意协议[/color]"
+        "focus": "<font color=\"tomato\">由于最终用户协议(EULA),你必须手动同意协议</font>"
     }
 }

--- a/assets/resource/base/pipeline/Stronghold.json
+++ b/assets/resource/base/pipeline/Stronghold.json
@@ -9,7 +9,7 @@
             "stronghold_in_map",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入要塞任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入要塞任务</font>"
     },
     "stronghold_entry": {
         "recognition": "Or",
@@ -53,7 +53,7 @@
             "no_group",
             "stronghold_entry"
         ],
-        "focus": "[color:DeepSkyBlue]组织主界面入口[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
     },
     "stronghold_gameplay": {
         "recognition": "TemplateMatch",
@@ -80,7 +80,7 @@
             "stronghold_mode",
             "[JumpBack]swipe_for_stronghold_mode"
         ],
-        "focus": "[color:DeepSkyBlue]确认选中组织玩法按钮[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
     },
     "stronghold_mode": {
         "recognition": "TemplateMatch",
@@ -104,7 +104,7 @@
             "[JumpBack]stronghold_mode",
             "group_mode_not_open"
         ],
-        "focus": "[color:DeepSkyBlue]进入要塞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入要塞</font>"
     },
     "stronghold_in_map": {
         "recognition": "TemplateMatch",
@@ -121,7 +121,7 @@
             "stronghold_end",
             "stronghold_to_fire_stronghold"
         ],
-        "focus": "[color:DeepSkyBlue]在要塞地图[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">在要塞地图</font>"
     },
     "swipe_for_stronghold_mode": {
         "recognition": "TemplateMatch",
@@ -147,7 +147,7 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "[color:DeepSkyBlue]寻找要塞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">寻找要塞</font>"
     },
     "stronghold_to_fire_stronghold": {
         "recognition": "TemplateMatch",
@@ -166,7 +166,7 @@
             "stronghold_to_fight",
             "[JumpBack]stronghold_to_fire_stronghold"
         ],
-        "focus": "[color:DeepSkyBlue]点击火要塞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击火要塞</font>"
     },
     "stronghold_to_fight": {
         "recognition": "OCR",
@@ -187,7 +187,7 @@
             "stronghold_in_stronghold",
             "[JumpBack]stronghold_to_fight"
         ],
-        "focus": "[color:DeepSkyBlue]进入火要塞[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入火要塞</font>"
     },
     "stronghold_personal_point_award": {
         "recognition": "OCR",
@@ -248,7 +248,7 @@
             "stronghold_finished",
             "[JumpBack]stronghold_substitution"
         ],
-        "focus": "[color:darkgray]在要塞中，向右走[/color]"
+        "focus": "<font color=\"darkgray\">在要塞中，向右走</font>"
     },
     "stronghold_in_match": {
         "recognition": "OCR",
@@ -292,7 +292,7 @@
             "[JumpBack]stronghold_match_win",
             "stronghold_finished"
         ],
-        "focus": "[color:DeepSkyBlue]敌人退出了,你获胜[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
     },
     "stronghold_without_match_win": {
         "recognition": "OCR",
@@ -312,7 +312,7 @@
             "stronghold_in_stronghold",
             "stronghold_finished"
         ],
-        "focus": "[color:DeepSkyBlue]回到战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
     },
     "stronghold_fighting": {
         "recognition": "OCR",
@@ -336,7 +336,7 @@
             "[JumpBack]stronghold_match_win",
             "stronghold_finished"
         ],
-        "focus": "[color:DeepSkyBlue]开始战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
     },
     "stronghold_winner_decided": {
         "recognition": "TemplateMatch",
@@ -378,7 +378,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]要塞到时间了[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">要塞到时间了</font>"
     },
     "stronghold_battle_end": {
         "recognition": "OCR",
@@ -403,7 +403,7 @@
             "stronghold_end",
             "[JumpBack]stronghold_battle_end"
         ],
-        "focus": "[color:DeepSkyBlue]战斗结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗结束</font>"
     },
     "stronghold_substitution": {
         "recognition": "TemplateMatch",
@@ -431,7 +431,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入要塞结算[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入要塞结算</font>"
     },
     "stronghold_click_All_skill": {
         "recognition": "TemplateMatch",
@@ -576,6 +576,6 @@
             }
         ],
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]连点器战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">连点器战斗</font>"
     }
 }

--- a/assets/resource/base/pipeline/Stronghold.json
+++ b/assets/resource/base/pipeline/Stronghold.json
@@ -9,7 +9,9 @@
             "stronghold_in_map",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入要塞任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入要塞任务</font>"
+        }
     },
     "stronghold_entry": {
         "recognition": "Or",
@@ -53,7 +55,9 @@
             "no_group",
             "stronghold_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">组织主界面入口</font>"
+        }
     },
     "stronghold_gameplay": {
         "recognition": "TemplateMatch",
@@ -80,7 +84,9 @@
             "stronghold_mode",
             "[JumpBack]swipe_for_stronghold_mode"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认选中组织玩法按钮</font>"
+        }
     },
     "stronghold_mode": {
         "recognition": "TemplateMatch",
@@ -104,7 +110,9 @@
             "[JumpBack]stronghold_mode",
             "group_mode_not_open"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入要塞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入要塞</font>"
+        }
     },
     "stronghold_in_map": {
         "recognition": "TemplateMatch",
@@ -121,7 +129,9 @@
             "stronghold_end",
             "stronghold_to_fire_stronghold"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">在要塞地图</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">在要塞地图</font>"
+        }
     },
     "swipe_for_stronghold_mode": {
         "recognition": "TemplateMatch",
@@ -147,7 +157,9 @@
         ],
         "duration": 300,
         "post_delay": 800,
-        "focus": "<font color=\"DeepSkyBlue\">寻找要塞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">寻找要塞</font>"
+        }
     },
     "stronghold_to_fire_stronghold": {
         "recognition": "TemplateMatch",
@@ -166,7 +178,9 @@
             "stronghold_to_fight",
             "[JumpBack]stronghold_to_fire_stronghold"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击火要塞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击火要塞</font>"
+        }
     },
     "stronghold_to_fight": {
         "recognition": "OCR",
@@ -187,7 +201,9 @@
             "stronghold_in_stronghold",
             "[JumpBack]stronghold_to_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入火要塞</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入火要塞</font>"
+        }
     },
     "stronghold_personal_point_award": {
         "recognition": "OCR",
@@ -248,7 +264,9 @@
             "stronghold_finished",
             "[JumpBack]stronghold_substitution"
         ],
-        "focus": "<font color=\"darkgray\">在要塞中，向右走</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">在要塞中，向右走</font>"
+        }
     },
     "stronghold_in_match": {
         "recognition": "OCR",
@@ -292,7 +310,9 @@
             "[JumpBack]stronghold_match_win",
             "stronghold_finished"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">敌人退出了,你获胜</font>"
+        }
     },
     "stronghold_without_match_win": {
         "recognition": "OCR",
@@ -312,7 +332,9 @@
             "stronghold_in_stronghold",
             "stronghold_finished"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        }
     },
     "stronghold_fighting": {
         "recognition": "OCR",
@@ -336,7 +358,9 @@
             "[JumpBack]stronghold_match_win",
             "stronghold_finished"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        }
     },
     "stronghold_winner_decided": {
         "recognition": "TemplateMatch",
@@ -378,7 +402,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">要塞到时间了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">要塞到时间了</font>"
+        }
     },
     "stronghold_battle_end": {
         "recognition": "OCR",
@@ -403,7 +429,9 @@
             "stronghold_end",
             "[JumpBack]stronghold_battle_end"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗结束</font>"
+        }
     },
     "stronghold_substitution": {
         "recognition": "TemplateMatch",
@@ -431,7 +459,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入要塞结算</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入要塞结算</font>"
+        }
     },
     "stronghold_click_All_skill": {
         "recognition": "TemplateMatch",
@@ -576,6 +606,8 @@
             }
         ],
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">连点器战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">连点器战斗</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Summer_plan.json
+++ b/assets/resource/base/pipeline/Summer_plan.json
@@ -7,7 +7,9 @@
             "summer_plan_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入夏日回馈任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入夏日回馈任务</font>"
+        }
     },
     "summer_plan_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +37,9 @@
             "[JumpBack]swipes_for_summer_plan",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入活动</font>"
+        }
     },
     "find_summer_plan": {
         "recognition": "OCR",
@@ -54,7 +58,9 @@
             "select_summer_plan",
             "find_summer_plan"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到夏日回馈</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到夏日回馈</font>"
+        }
     },
     "select_summer_plan": {
         "recognition": "OCR",
@@ -75,7 +81,9 @@
             "summer_plan_get",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">选中夏日回馈</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选中夏日回馈</font>"
+        }
     },
     "swipes_for_summer_plan": {
         "max_hit": 5,
@@ -95,7 +103,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往夏日计划</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往夏日计划</font>"
+        }
     },
     "summer_plan_get": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Summer_plan.json
+++ b/assets/resource/base/pipeline/Summer_plan.json
@@ -7,7 +7,7 @@
             "summer_plan_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入夏日回馈任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入夏日回馈任务</font>"
     },
     "summer_plan_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +35,7 @@
             "[JumpBack]swipes_for_summer_plan",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入活动</font>"
     },
     "find_summer_plan": {
         "recognition": "OCR",
@@ -54,7 +54,7 @@
             "select_summer_plan",
             "find_summer_plan"
         ],
-        "focus": "[color:DeepSkyBlue]找到夏日回馈[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到夏日回馈</font>"
     },
     "select_summer_plan": {
         "recognition": "OCR",
@@ -75,7 +75,7 @@
             "summer_plan_get",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]选中夏日回馈[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选中夏日回馈</font>"
     },
     "swipes_for_summer_plan": {
         "max_hit": 5,
@@ -95,7 +95,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往夏日计划[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往夏日计划</font>"
     },
     "summer_plan_get": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Switch_account.json
+++ b/assets/resource/base/pipeline/Switch_account.json
@@ -7,7 +7,9 @@
             "switch_account_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入切换账号任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入切换账号任务</font>"
+        }
     },
     "switch_account_enter": {
         "recognition": "TemplateMatch",
@@ -68,7 +70,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已在目标区</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已在目标区</font>"
+        }
     },
     "switch_account_logout": {
         "recognition": "TemplateMatch",
@@ -228,7 +232,9 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "<font color=\"tomato\">没有找到目标区</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">没有找到目标区</font>"
+        }
     },
     "switch_account_in_start_game": {
         "recognition": "TemplateMatch",
@@ -244,7 +250,9 @@
         "next": [
             "click_start_game"
         ],
-        "focus": "<font color=\"tomato\">进入开始游戏界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">进入开始游戏界面</font>"
+        }
     },
     "switch_account_to_switch_social_media_account": {
         "recognition": "TemplateMatch",
@@ -398,7 +406,9 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "<font color=\"tomato\">没有找到目标账号</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">没有找到目标账号</font>"
+        },
         "$doc": "为了适配不同分辨率只能使用文字识别"
     }
 }

--- a/assets/resource/base/pipeline/Switch_account.json
+++ b/assets/resource/base/pipeline/Switch_account.json
@@ -7,7 +7,7 @@
             "switch_account_enter",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入切换账号任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入切换账号任务</font>"
     },
     "switch_account_enter": {
         "recognition": "TemplateMatch",
@@ -68,7 +68,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]已在目标区[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已在目标区</font>"
     },
     "switch_account_logout": {
         "recognition": "TemplateMatch",
@@ -228,7 +228,7 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "[color:tomato]没有找到目标区[/color]"
+        "focus": "<font color=\"tomato\">没有找到目标区</font>"
     },
     "switch_account_in_start_game": {
         "recognition": "TemplateMatch",
@@ -244,7 +244,7 @@
         "next": [
             "click_start_game"
         ],
-        "focus": "[color:tomato]进入开始游戏界面[/color]"
+        "focus": "<font color=\"tomato\">进入开始游戏界面</font>"
     },
     "switch_account_to_switch_social_media_account": {
         "recognition": "TemplateMatch",
@@ -398,7 +398,7 @@
         "pre_delay": 0,
         "action": "StopTask",
         "post_delay": 0,
-        "focus": "[color:tomato]没有找到目标账号[/color]",
+        "focus": "<font color=\"tomato\">没有找到目标账号</font>",
         "$doc": "为了适配不同分辨率只能使用文字识别"
     }
 }

--- a/assets/resource/base/pipeline/Team_dash.json
+++ b/assets/resource/base/pipeline/Team_dash.json
@@ -7,7 +7,7 @@
             "team_dash_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入小队突袭任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入小队突袭任务</font>"
     },
     "team_dash_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -27,7 +27,7 @@
             "team_dash_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "team_dash_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -45,7 +45,7 @@
             "team_dash_in_center_enter",
             "team_dash_not_in_center_enter"
         ],
-        "focus": "[color:DeepSkyBlue]奖励中心有奖励没领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
     },
     "team_dash_ac_entry": {
         "recognition": "TemplateMatch",
@@ -68,7 +68,7 @@
             "team_dash_not_in_center_enter",
             "team_dash_ac_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
     },
     "team_dash_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -96,7 +96,7 @@
             "team_dash_group_help_done",
             "team_dash_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]小队突袭未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">小队突袭未完成</font>"
     },
     "team_dash_ac_done": {
         "recognition": "TemplateMatch",
@@ -110,7 +110,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]小队突袭已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">小队突袭已完成</font>"
     },
     "team_dash_group_help_undone": {
         "recognition": "TemplateMatch",
@@ -131,7 +131,7 @@
             "team_dash_my_help_done",
             "team_dash_group_help_undone"
         ],
-        "focus": "[color:DeepSkyBlue]进入组织助战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入组织助战</font>"
     },
     "team_dash_not_in_group": {
         "recognition": "TemplateMatch",
@@ -158,7 +158,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "dash_or_exit",
-        "focus": "[color:DeepSkyBlue]选择组织助战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">选择组织助战</font>"
     },
     "team_dash_my_help_done": {
         "recognition": "TemplateMatch",
@@ -173,7 +173,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "team_dash_invite_page",
-        "focus": "[color:DeepSkyBlue]我的助战已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">我的助战已完成</font>"
     },
     "team_dash_my_help_undone": {
         "recognition": "TemplateMatch",
@@ -193,7 +193,7 @@
             "team_dash_my_help_award",
             "team_dash_my_help_undone"
         ],
-        "focus": "[color:DeepSkyBlue]我的助战未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">我的助战未完成</font>"
     },
     "team_dash_my_help_award": {
         "recognition": "TemplateMatch",
@@ -207,7 +207,7 @@
         "pre_delay": 0,
         "action": "Click",
         "next": "close_my_help",
-        "focus": "[color:DeepSkyBlue]领取我的助战奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取我的助战奖励</font>"
     },
     "close_my_help": {
         "recognition": "And",
@@ -246,7 +246,7 @@
             "team_dash_invite_page",
             "[JumpBack]close_my_help"
         ],
-        "focus": "[color:DeepSkyBlue]关闭我的助战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭我的助战</font>"
     },
     "team_dash_invite_page": {
         "recognition": "TemplateMatch",
@@ -265,7 +265,7 @@
             "dash_or_exit",
             "retry_failed"
         ],
-        "focus": "[color:DeepSkyBlue]进入助战邀请界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入助战邀请界面</font>"
     },
     "team_dash_invite_ninja": {
         "recognition": "TemplateMatch",
@@ -281,7 +281,7 @@
         "post_wait_freezes": 200,
         "post_delay": 0,
         "next": "dash_or_exit",
-        "focus": "[color:DeepSkyBlue]邀请组织助战忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">邀请组织助战忍者</font>"
     },
     "can_not_invite": {
         "max_hit": 5,
@@ -304,7 +304,7 @@
             1,
             1
         ],
-        "focus": "[color:darkgray]当前页面没有可邀请的助战忍者[/color]"
+        "focus": "<font color=\"darkgray\">当前页面没有可邀请的助战忍者</font>"
     },
     "dash_or_exit": {
         "pre_wait_freezes": 300,
@@ -346,7 +346,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "close_team_dash",
-        "focus": "[color:darkgray]达到今日收益上限[/color]"
+        "focus": "<font color=\"darkgray\">达到今日收益上限</font>"
     },
     "team_dash_auto_fight": {
         "max_hit": 10,
@@ -379,7 +379,7 @@
             "team_dash_auto_fight_retry_failed",
             "unknow_error"
         ],
-        "focus": "[color:DeepSkyBlue]小队突袭自动战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">小队突袭自动战斗</font>"
     },
     "team_dash_same_ninja": {
         "recognition": "OCR",
@@ -513,7 +513,7 @@
             "team_dash_matching",
             "dash_or_exit"
         ],
-        "focus": "[color:DeepSkyBlue]点击继续战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击继续战斗</font>"
     },
     "team_dash_matching": {
         "recognition": "OCR",
@@ -568,7 +568,7 @@
             "team_dash_do_not_remind_gold",
             "team_dash_keep_fight"
         ],
-        "focus": "[color:DeepSkyBlue]点击本周不再提醒[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击本周不再提醒</font>"
     },
     "check_in_team_dash_sweep": {
         "recognition": "OCR",
@@ -689,7 +689,7 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]胜利退出[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">胜利退出</font>"
     },
     "check_not_in_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -705,7 +705,7 @@
         "next": [
             "dash_or_exit"
         ],
-        "focus": "[color:DeepSkyBlue]检测不在进行小队突袭战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测不在进行小队突袭战斗</font>"
     },
     "team_dash_above_kage_sweep": {
         "recognition": "TemplateMatch",
@@ -728,7 +728,7 @@
             "team_dash_above_kage_sweep",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]超影扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">超影扫荡</font>"
     },
     "team_dash_above_kage_quit": {
         "recognition": "Or",
@@ -788,7 +788,7 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]关闭小队突袭[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">关闭小队突袭</font>"
     },
     "close_team_dash_out_team_sign": {
         "recognition": "OCR",
@@ -809,7 +809,7 @@
             "close_team_dash_without_out_team_sign",
             "close_team_dash_out_team_sign"
         ],
-        "focus": "[color:DeepSkyBlue]确认退队[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认退队</font>"
     },
     "close_team_dash_without_out_team_sign": {
         "recognition": "OCR",
@@ -843,7 +843,7 @@
         "threshold": 0.9,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:pink]勾选4倍奖励[/color]"
+        "focus": "<font color=\"pink\">勾选4倍奖励</font>"
     },
     "team_dash_check_not_4x_reward": {
         "recognition": "TemplateMatch",
@@ -883,6 +883,6 @@
             "dash_or_exit",
             "team_dash_confirm_4x_select"
         ],
-        "focus": "[color:pink]点击确认勾选4倍奖励[/color]"
+        "focus": "<font color=\"pink\">点击确认勾选4倍奖励</font>"
     }
 }

--- a/assets/resource/base/pipeline/Team_dash.json
+++ b/assets/resource/base/pipeline/Team_dash.json
@@ -7,7 +7,9 @@
             "team_dash_ac_entry",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入小队突袭任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入小队突袭任务</font>"
+        }
     },
     "team_dash_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -27,7 +29,9 @@
             "team_dash_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "team_dash_not_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -45,7 +49,9 @@
             "team_dash_in_center_enter",
             "team_dash_not_in_center_enter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奖励中心有奖励没领取</font>"
+        }
     },
     "team_dash_ac_entry": {
         "recognition": "TemplateMatch",
@@ -68,7 +74,9 @@
             "team_dash_not_in_center_enter",
             "team_dash_ac_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入奖励中心</font>"
+        }
     },
     "team_dash_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -96,7 +104,9 @@
             "team_dash_group_help_done",
             "team_dash_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">小队突袭未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">小队突袭未完成</font>"
+        }
     },
     "team_dash_ac_done": {
         "recognition": "TemplateMatch",
@@ -110,7 +120,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">小队突袭已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">小队突袭已完成</font>"
+        }
     },
     "team_dash_group_help_undone": {
         "recognition": "TemplateMatch",
@@ -131,7 +143,9 @@
             "team_dash_my_help_done",
             "team_dash_group_help_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入组织助战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入组织助战</font>"
+        }
     },
     "team_dash_not_in_group": {
         "recognition": "TemplateMatch",
@@ -158,7 +172,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "dash_or_exit",
-        "focus": "<font color=\"DeepSkyBlue\">选择组织助战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">选择组织助战</font>"
+        }
     },
     "team_dash_my_help_done": {
         "recognition": "TemplateMatch",
@@ -173,7 +189,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "team_dash_invite_page",
-        "focus": "<font color=\"DeepSkyBlue\">我的助战已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">我的助战已完成</font>"
+        }
     },
     "team_dash_my_help_undone": {
         "recognition": "TemplateMatch",
@@ -193,7 +211,9 @@
             "team_dash_my_help_award",
             "team_dash_my_help_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">我的助战未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">我的助战未完成</font>"
+        }
     },
     "team_dash_my_help_award": {
         "recognition": "TemplateMatch",
@@ -207,7 +227,9 @@
         "pre_delay": 0,
         "action": "Click",
         "next": "close_my_help",
-        "focus": "<font color=\"DeepSkyBlue\">领取我的助战奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取我的助战奖励</font>"
+        }
     },
     "close_my_help": {
         "recognition": "And",
@@ -246,7 +268,9 @@
             "team_dash_invite_page",
             "[JumpBack]close_my_help"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭我的助战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭我的助战</font>"
+        }
     },
     "team_dash_invite_page": {
         "recognition": "TemplateMatch",
@@ -265,7 +289,9 @@
             "dash_or_exit",
             "retry_failed"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入助战邀请界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入助战邀请界面</font>"
+        }
     },
     "team_dash_invite_ninja": {
         "recognition": "TemplateMatch",
@@ -281,7 +307,9 @@
         "post_wait_freezes": 200,
         "post_delay": 0,
         "next": "dash_or_exit",
-        "focus": "<font color=\"DeepSkyBlue\">邀请组织助战忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">邀请组织助战忍者</font>"
+        }
     },
     "can_not_invite": {
         "max_hit": 5,
@@ -304,7 +332,9 @@
             1,
             1
         ],
-        "focus": "<font color=\"darkgray\">当前页面没有可邀请的助战忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">当前页面没有可邀请的助战忍者</font>"
+        }
     },
     "dash_or_exit": {
         "pre_wait_freezes": 300,
@@ -346,7 +376,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "close_team_dash",
-        "focus": "<font color=\"darkgray\">达到今日收益上限</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">达到今日收益上限</font>"
+        }
     },
     "team_dash_auto_fight": {
         "max_hit": 10,
@@ -379,7 +411,9 @@
             "team_dash_auto_fight_retry_failed",
             "unknow_error"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">小队突袭自动战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">小队突袭自动战斗</font>"
+        }
     },
     "team_dash_same_ninja": {
         "recognition": "OCR",
@@ -513,7 +547,9 @@
             "team_dash_matching",
             "dash_or_exit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击继续战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击继续战斗</font>"
+        }
     },
     "team_dash_matching": {
         "recognition": "OCR",
@@ -568,7 +604,9 @@
             "team_dash_do_not_remind_gold",
             "team_dash_keep_fight"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击本周不再提醒</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击本周不再提醒</font>"
+        }
     },
     "check_in_team_dash_sweep": {
         "recognition": "OCR",
@@ -603,7 +641,9 @@
             "check_in_team_dash_sweep",
             "[JumpBack]team_dash_sweep_win"
         ],
-        "focus": "没有检测到自动战斗"
+        "focus": {
+            "Node.Action.Starting": "没有检测到自动战斗"
+        }
     },
     "team_dash_in_auto_battle": {
         "recognition": "OCR",
@@ -673,7 +713,9 @@
             "check_in_team_dash_sweep",
             "[JumpBack]team_dash_sweep_win"
         ],
-        "focus": "开启自动战斗",
+        "focus": {
+            "Node.Action.Starting": "开启自动战斗"
+        },
         "$doc": "好像老区没有默认开自动战斗"
     },
     "team_dash_sweep_win": {
@@ -689,7 +731,9 @@
         "action": "Click",
         "post_wait_freezes": 300,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">胜利退出</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">胜利退出</font>"
+        }
     },
     "check_not_in_team_dash_sweep": {
         "recognition": "TemplateMatch",
@@ -705,7 +749,9 @@
         "next": [
             "dash_or_exit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测不在进行小队突袭战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测不在进行小队突袭战斗</font>"
+        }
     },
     "team_dash_above_kage_sweep": {
         "recognition": "TemplateMatch",
@@ -728,7 +774,9 @@
             "team_dash_above_kage_sweep",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">超影扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">超影扫荡</font>"
+        }
     },
     "team_dash_above_kage_quit": {
         "recognition": "Or",
@@ -788,7 +836,9 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">关闭小队突袭</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">关闭小队突袭</font>"
+        }
     },
     "close_team_dash_out_team_sign": {
         "recognition": "OCR",
@@ -809,7 +859,9 @@
             "close_team_dash_without_out_team_sign",
             "close_team_dash_out_team_sign"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认退队</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认退队</font>"
+        }
     },
     "close_team_dash_without_out_team_sign": {
         "recognition": "OCR",
@@ -843,7 +895,9 @@
         "threshold": 0.9,
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"pink\">勾选4倍奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">勾选4倍奖励</font>"
+        }
     },
     "team_dash_check_not_4x_reward": {
         "recognition": "TemplateMatch",
@@ -883,6 +937,8 @@
             "dash_or_exit",
             "team_dash_confirm_4x_select"
         ],
-        "focus": "<font color=\"pink\">点击确认勾选4倍奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"pink\">点击确认勾选4倍奖励</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/Treasure_gathering_trial_award.json
+++ b/assets/resource/base/pipeline/Treasure_gathering_trial_award.json
@@ -55,7 +55,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">聚宝试炼奖励已领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">聚宝试炼奖励已领取</font>"
+        }
     },
     "treasure_gathering_trial_box": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Treasure_gathering_trial_award.json
+++ b/assets/resource/base/pipeline/Treasure_gathering_trial_award.json
@@ -55,7 +55,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]聚宝试炼奖励已领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">聚宝试炼奖励已领取</font>"
     },
     "treasure_gathering_trial_box": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Use_energy.json
+++ b/assets/resource/base/pipeline/Use_energy.json
@@ -6,7 +6,7 @@
             "use_energy_by_ninja_piece",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入使用体力任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入使用体力任务</font>"
     },
     "use_energy_by_ninja_piece": {
         "recognition": "TemplateMatch",
@@ -33,7 +33,7 @@
             "elite_entry",
             "[JumpBack]use_energy_by_ninja_piece"
         ],
-        "focus": "[color:DeepSkyBlue]刷忍者碎片[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">刷忍者碎片</font>"
     },
     "elite_entry": {
         "recognition": "TemplateMatch",
@@ -52,7 +52,7 @@
             "use_energy_ez_sweep_entry",
             "elite_entry"
         ],
-        "focus": "[color:DeepSkyBlue]进入精英副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入精英副本</font>"
     },
     "use_energy_ez_sweep_entry": {
         "recognition": "TemplateMatch",
@@ -71,7 +71,7 @@
             "use_energy_ez_sweep",
             "[JumpBack]use_energy_ez_sweep_entry"
         ],
-        "focus": "[color:DeepSkyBlue]便捷扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">便捷扫荡</font>"
     },
     "use_energy_ez_sweep": {
         "max_hit": 5,
@@ -118,7 +118,7 @@
             "use_energy_ez_sweep",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]继续扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
     },
     "use_energy_not_enough_sign": {
         "recognition": "TemplateMatch",
@@ -139,7 +139,7 @@
         ],
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]体力不足[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">体力不足</font>"
     },
     "use_energy_finish": {
         "recognition": "TemplateMatch",
@@ -157,7 +157,7 @@
             "use_energy_finished",
             "use_energy_finish"
         ],
-        "focus": "[color:DeepSkyBlue]扫荡完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
     },
     "use_energy_finished": {
         "recognition": "TemplateMatch",
@@ -170,7 +170,7 @@
         "template": "Use_energy/sweep_finish.png",
         "inverse": true,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]扫荡完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
     },
     "use_energy_finish_1": {
         "recognition": "OCR",
@@ -187,7 +187,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]扫荡完成或者没有选中扫荡副本[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">扫荡完成或者没有选中扫荡副本</font>"
     },
     "use_energy_check_one_key_select": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Use_energy.json
+++ b/assets/resource/base/pipeline/Use_energy.json
@@ -6,7 +6,9 @@
             "use_energy_by_ninja_piece",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入使用体力任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入使用体力任务</font>"
+        }
     },
     "use_energy_by_ninja_piece": {
         "recognition": "TemplateMatch",
@@ -33,7 +35,9 @@
             "elite_entry",
             "[JumpBack]use_energy_by_ninja_piece"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">刷忍者碎片</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">刷忍者碎片</font>"
+        }
     },
     "elite_entry": {
         "recognition": "TemplateMatch",
@@ -52,7 +56,9 @@
             "use_energy_ez_sweep_entry",
             "elite_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入精英副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入精英副本</font>"
+        }
     },
     "use_energy_ez_sweep_entry": {
         "recognition": "TemplateMatch",
@@ -71,7 +77,9 @@
             "use_energy_ez_sweep",
             "[JumpBack]use_energy_ez_sweep_entry"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">便捷扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">便捷扫荡</font>"
+        }
     },
     "use_energy_ez_sweep": {
         "max_hit": 5,
@@ -118,7 +126,9 @@
             "use_energy_ez_sweep",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">继续扫荡</font>"
+        }
     },
     "use_energy_not_enough_sign": {
         "recognition": "TemplateMatch",
@@ -139,7 +149,9 @@
         ],
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">体力不足</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">体力不足</font>"
+        }
     },
     "use_energy_finish": {
         "recognition": "TemplateMatch",
@@ -157,7 +169,9 @@
             "use_energy_finished",
             "use_energy_finish"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
+        }
     },
     "use_energy_finished": {
         "recognition": "TemplateMatch",
@@ -170,7 +184,9 @@
         "template": "Use_energy/sweep_finish.png",
         "inverse": true,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">扫荡完成</font>"
+        }
     },
     "use_energy_finish_1": {
         "recognition": "OCR",
@@ -187,7 +203,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">扫荡完成或者没有选中扫荡副本</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">扫荡完成或者没有选中扫荡副本</font>"
+        }
     },
     "use_energy_check_one_key_select": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/Weekly_win.json
+++ b/assets/resource/base/pipeline/Weekly_win.json
@@ -10,7 +10,7 @@
             "[JumpBack]weekly_win_match_fighting",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]开始周胜任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始周胜任务</font>"
     },
     "goto_duel_field_by_guide": {
         "recognition": "Custom",
@@ -30,7 +30,7 @@
             "[JumpBack]go_to_war",
             "goto_duel_field_by_guide"
         ],
-        "focus": "[color:DeepSkyBlue]进入决斗场[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
     },
     "weekly_win_weekly_award": {
         "recognition": "OCR",
@@ -66,7 +66,7 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "[color:darkgray]关闭周榜更新提示[/color]"
+        "focus": "<font color=\"darkgray\">关闭周榜更新提示</font>"
     },
     "weekly_win_mouthly_award": {
         "recognition": "OCR",
@@ -82,7 +82,7 @@
         ],
         "action": "Click",
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]月度段位结算奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">月度段位结算奖励</font>"
     },
     "weekly_win_mouthly_reset_award": {
         "recognition": "TemplateMatch",
@@ -96,7 +96,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]月度段位重置奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">月度段位重置奖励</font>"
     },
     "weekly_win_in_duel_field": {
         "recognition": "OCR",
@@ -119,7 +119,7 @@
             "[JumpBack]weekly_win_mouthly_reset_award",
             "[JumpBack]weekly_win"
         ],
-        "focus": "[color:DeepSkyBlue]已在决斗场界面[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
     },
     "weekly_win_match_fighting": {
         "recognition": "TemplateMatch",
@@ -142,7 +142,7 @@
             "battle_end",
             "[JumpBack]weekly_win_match_fighting"
         ],
-        "focus": "[color:DeepSkyBlue]开始战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
     },
     "winner_decided": {
         "recognition": "TemplateMatch",
@@ -200,7 +200,7 @@
             "[JumpBack]game_resource_loading",
             "weekly_win"
         ],
-        "focus": "[color:DeepSkyBlue]对局结束[/color]",
+        "focus": "<font color=\"DeepSkyBlue\">对局结束</font>",
         "$doc": "容易卡时间卡bug的忍者太多增加超时时间"
     },
     "weekly_win_success": {
@@ -229,7 +229,7 @@
             "[JumpBack]loading_page",
             "win_counter"
         ],
-        "focus": "[color:DeepSkyBlue]战斗胜利[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
     },
     "win_counter": {
         "recognition": "TemplateMatch",
@@ -285,7 +285,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]周胜任务结束[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">周胜任务结束</font>"
     },
     "weekly_win_preset_prewar": {
         "recognition": "OCR",
@@ -315,7 +315,7 @@
         "on_error": [
             "[JumpBack]go_to_war"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:点击调整阵容[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:点击调整阵容</font>"
     },
     "weekly_win_preset_entry": {
         "recognition": "TemplateMatch",
@@ -332,7 +332,7 @@
         "next": [
             "weekly_win_preset_open"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:识别到锁定界面,点锁定阵容前切预设[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:识别到锁定界面,点锁定阵容前切预设</font>"
     },
     "weekly_win_preset_open": {
         "recognition": "OCR",
@@ -366,7 +366,7 @@
         "on_error": [
             "[JumpBack]weekly_win_rank_confirm_ninja"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:打开预设面板[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:打开预设面板</font>"
     },
     "weekly_win_switch_preset": {
         "recognition": "OCR",
@@ -391,7 +391,7 @@
         "next": [
             "weekly_win_preset_confirm"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:选择预设页签[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:选择预设页签</font>"
     },
     "weekly_win_preset_confirm": {
         "recognition": "OCR",
@@ -413,7 +413,7 @@
         "on_error": [
             "weekly_win_preset_confirm_pos"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:确认选择预设[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设</font>"
     },
     "weekly_win_preset_confirm_pos": {
         "recognition": "DirectHit",
@@ -429,7 +429,7 @@
         "next": [
             "weekly_win_preset_save"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:确认选择预设(坐标兜底)[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设(坐标兜底)</font>"
     },
     "weekly_win_preset_save": {
         "recognition": "OCR",
@@ -463,7 +463,7 @@
         "on_error": [
             "weekly_win_preset_save_pos"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:保存阵容[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:保存阵容</font>"
     },
     "weekly_win_preset_save_pos": {
         "recognition": "DirectHit",
@@ -489,7 +489,7 @@
             "[JumpBack]weekly_win_substitution",
             "[JumpBack]go_to_war"
         ],
-        "focus": "[color:DeepSkyBlue]切换预设:保存阵容(坐标兜底)[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">切换预设:保存阵容(坐标兜底)</font>"
     },
     "weekly_win_rank_up": {
         "recognition": "OCR",
@@ -546,7 +546,7 @@
             "weekly_win_without_fail",
             "weekly_win_fail"
         ],
-        "focus": "[color:DeepSkyBlue]战斗失败[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗失败</font>"
     },
     "weekly_win_without_fail": {
         "recognition": "TemplateMatch",
@@ -625,7 +625,7 @@
             "[JumpBack]weekly_win_substitution",
             "[JumpBack]go_to_war"
         ],
-        "focus": "[color:DeepSkyBlue]点击开战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">点击开战</font>"
     },
     "weekly_win_locked": {
         "recognition": "TemplateMatch",
@@ -656,7 +656,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:tomato]无法进入战斗提示[/color]"
+        "focus": "<font color=\"tomato\">无法进入战斗提示</font>"
     },
     "battle_again": {
         "recognition": "TemplateMatch",
@@ -672,7 +672,7 @@
         "next": [
             "refuse_battle_again"
         ],
-        "focus": "[color:DeepSkyBlue]收到再战邀请[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">收到再战邀请</font>"
     },
     "refuse_battle_again": {
         "recognition": "OCR",
@@ -705,7 +705,7 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]战斗异常提示[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
     },
     "tips_confirm": {
         "recognition": "OCR",
@@ -749,7 +749,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]ban忍者[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">ban忍者</font>"
     },
     "weekly_win_rank_confirm_ninja": {
         "recognition": "TemplateMatch",
@@ -766,7 +766,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 5000,
-        "focus": "[color:DeepSkyBlue]锁定阵容[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">锁定阵容</font>"
     },
     "weekly_win_in_seasonal_awards": {
         "recognition": "OCR",
@@ -812,7 +812,7 @@
             "weekly_win_in_duel_mission",
             "weekly_win_duel_mission"
         ],
-        "focus": "[color:DeepSkyBlue]进入决斗任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入决斗任务</font>"
     },
     "weekly_win_in_duel_mission": {
         "recognition": "OCR",
@@ -832,7 +832,7 @@
             "weekly_win_get_weekly_duel_mission_award_1",
             "weekly_win_get_weekly_duel_mission_award_1_done"
         ],
-        "focus": "[color:DeepSkyBlue]在决斗任务中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">在决斗任务中</font>"
     },
     "weekly_win_get_weekly_duel_mission_award_1": {
         "max_hit": 5,
@@ -962,7 +962,7 @@
         "next": [
             "close_mission_and_back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]确认无奖励可领取[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认无奖励可领取</font>"
     },
     "close_mission_and_back_main_screen": {
         "recognition": "OCR",
@@ -997,7 +997,7 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 200,
-        "focus": "[color:DeepSkyBlue]领取决斗任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取决斗任务奖励</font>"
     },
     "weekly_win_check_daily_duel_mission_recover_award": {
         "recognition": "TemplateMatch",
@@ -1017,7 +1017,7 @@
             "[JumpBack]weekly_win_check_daily_duel_mission_recover_award",
             "weekly_win_check_daily_duel_mission_without_recover_award"
         ],
-        "focus": "[color:DeepSkyBlue]追回过期决斗任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">追回过期决斗任务奖励</font>"
     },
     "weekly_win_check_daily_duel_mission_without_recover_award": {
         "recognition": "TemplateMatch",
@@ -1035,7 +1035,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]没有可追回过期决斗任务奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">没有可追回过期决斗任务奖励</font>"
     },
     "weekly_win_check_daily_duel_mission_free_recover_award": {
         "recognition": "OCR",
@@ -1063,7 +1063,7 @@
             "weekly_win_check_daily_duel_mission_without_time_card",
             "[JumpBack]weekly_win_check_daily_duel_mission_free_recover_award"
         ],
-        "focus": "[color:DeepSkyBlue]有时间卡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">有时间卡</font>"
     },
     "weekly_win_check_daily_duel_mission_without_time_card": {
         "recognition": "OCR",
@@ -1099,7 +1099,7 @@
             "weekly_win_check_daily_duel_mission_back_fight",
             "[JumpBack]weekly_win_check_no_daily_duel_mission_recover_award"
         ],
-        "focus": "[color:DeepSkyBlue]确认没有可追回过期决斗宝箱[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认没有可追回过期决斗宝箱</font>"
     },
     "weekly_win_check_daily_duel_mission_back_fight": {
         "recognition": "And",
@@ -1135,7 +1135,7 @@
             "go_to_war_again",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]回到战斗[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
     },
     "weekly_win_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -1154,7 +1154,7 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "weekly_win_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1184,7 +1184,7 @@
             "[JumpBack]go_to_war",
             "weekly_win_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]匹配首胜任务未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">匹配首胜任务未完成</font>"
     },
     "weekly_win_combo_attack": {
         "pre_delay": 0,

--- a/assets/resource/base/pipeline/Weekly_win.json
+++ b/assets/resource/base/pipeline/Weekly_win.json
@@ -10,7 +10,9 @@
             "[JumpBack]weekly_win_match_fighting",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始周胜任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始周胜任务</font>"
+        }
     },
     "goto_duel_field_by_guide": {
         "recognition": "Custom",
@@ -30,7 +32,9 @@
             "[JumpBack]go_to_war",
             "goto_duel_field_by_guide"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入决斗场</font>"
+        }
     },
     "weekly_win_weekly_award": {
         "recognition": "OCR",
@@ -66,7 +70,9 @@
         "action": "Click",
         "post_wait_freezes": 200,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">关闭周榜更新提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">关闭周榜更新提示</font>"
+        }
     },
     "weekly_win_mouthly_award": {
         "recognition": "OCR",
@@ -82,7 +88,9 @@
         ],
         "action": "Click",
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">月度段位结算奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">月度段位结算奖励</font>"
+        }
     },
     "weekly_win_mouthly_reset_award": {
         "recognition": "TemplateMatch",
@@ -96,7 +104,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">月度段位重置奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">月度段位重置奖励</font>"
+        }
     },
     "weekly_win_in_duel_field": {
         "recognition": "OCR",
@@ -119,7 +129,9 @@
             "[JumpBack]weekly_win_mouthly_reset_award",
             "[JumpBack]weekly_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">已在决斗场界面</font>"
+        }
     },
     "weekly_win_match_fighting": {
         "recognition": "TemplateMatch",
@@ -142,7 +154,9 @@
             "battle_end",
             "[JumpBack]weekly_win_match_fighting"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">开始战斗</font>"
+        }
     },
     "winner_decided": {
         "recognition": "TemplateMatch",
@@ -200,7 +214,9 @@
             "[JumpBack]game_resource_loading",
             "weekly_win"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">对局结束</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">对局结束</font>"
+        },
         "$doc": "容易卡时间卡bug的忍者太多增加超时时间"
     },
     "weekly_win_success": {
@@ -229,7 +245,9 @@
             "[JumpBack]loading_page",
             "win_counter"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗胜利</font>"
+        }
     },
     "win_counter": {
         "recognition": "TemplateMatch",
@@ -278,14 +296,18 @@
         "next": [
             "go_to_war"
         ],
-        "focus": "再来一把！",
+        "focus": {
+            "Node.Action.Starting": "再来一把！"
+        },
         "$doc": "JumpBack to 'go_to_war'"
     },
     "weekly_win_stop": {
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">周胜任务结束</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">周胜任务结束</font>"
+        }
     },
     "weekly_win_preset_prewar": {
         "recognition": "OCR",
@@ -315,7 +337,9 @@
         "on_error": [
             "[JumpBack]go_to_war"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:点击调整阵容</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:点击调整阵容</font>"
+        }
     },
     "weekly_win_preset_entry": {
         "recognition": "TemplateMatch",
@@ -332,7 +356,9 @@
         "next": [
             "weekly_win_preset_open"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:识别到锁定界面,点锁定阵容前切预设</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:识别到锁定界面,点锁定阵容前切预设</font>"
+        }
     },
     "weekly_win_preset_open": {
         "recognition": "OCR",
@@ -366,7 +392,9 @@
         "on_error": [
             "[JumpBack]weekly_win_rank_confirm_ninja"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:打开预设面板</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:打开预设面板</font>"
+        }
     },
     "weekly_win_switch_preset": {
         "recognition": "OCR",
@@ -391,7 +419,9 @@
         "next": [
             "weekly_win_preset_confirm"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:选择预设页签</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:选择预设页签</font>"
+        }
     },
     "weekly_win_preset_confirm": {
         "recognition": "OCR",
@@ -413,7 +443,9 @@
         "on_error": [
             "weekly_win_preset_confirm_pos"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设</font>"
+        }
     },
     "weekly_win_preset_confirm_pos": {
         "recognition": "DirectHit",
@@ -429,7 +461,9 @@
         "next": [
             "weekly_win_preset_save"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设(坐标兜底)</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:确认选择预设(坐标兜底)</font>"
+        }
     },
     "weekly_win_preset_save": {
         "recognition": "OCR",
@@ -463,7 +497,9 @@
         "on_error": [
             "weekly_win_preset_save_pos"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:保存阵容</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:保存阵容</font>"
+        }
     },
     "weekly_win_preset_save_pos": {
         "recognition": "DirectHit",
@@ -489,7 +525,9 @@
             "[JumpBack]weekly_win_substitution",
             "[JumpBack]go_to_war"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">切换预设:保存阵容(坐标兜底)</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">切换预设:保存阵容(坐标兜底)</font>"
+        }
     },
     "weekly_win_rank_up": {
         "recognition": "OCR",
@@ -546,7 +584,9 @@
             "weekly_win_without_fail",
             "weekly_win_fail"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗失败</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗失败</font>"
+        }
     },
     "weekly_win_without_fail": {
         "recognition": "TemplateMatch",
@@ -625,7 +665,9 @@
             "[JumpBack]weekly_win_substitution",
             "[JumpBack]go_to_war"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">点击开战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">点击开战</font>"
+        }
     },
     "weekly_win_locked": {
         "recognition": "TemplateMatch",
@@ -656,7 +698,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"tomato\">无法进入战斗提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"tomato\">无法进入战斗提示</font>"
+        }
     },
     "battle_again": {
         "recognition": "TemplateMatch",
@@ -672,7 +716,9 @@
         "next": [
             "refuse_battle_again"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">收到再战邀请</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">收到再战邀请</font>"
+        }
     },
     "refuse_battle_again": {
         "recognition": "OCR",
@@ -705,7 +751,9 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">战斗异常提示</font>"
+        }
     },
     "tips_confirm": {
         "recognition": "OCR",
@@ -749,7 +797,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">ban忍者</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">ban忍者</font>"
+        }
     },
     "weekly_win_rank_confirm_ninja": {
         "recognition": "TemplateMatch",
@@ -766,7 +816,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 5000,
-        "focus": "<font color=\"DeepSkyBlue\">锁定阵容</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">锁定阵容</font>"
+        }
     },
     "weekly_win_in_seasonal_awards": {
         "recognition": "OCR",
@@ -812,7 +864,9 @@
             "weekly_win_in_duel_mission",
             "weekly_win_duel_mission"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入决斗任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入决斗任务</font>"
+        }
     },
     "weekly_win_in_duel_mission": {
         "recognition": "OCR",
@@ -832,7 +886,9 @@
             "weekly_win_get_weekly_duel_mission_award_1",
             "weekly_win_get_weekly_duel_mission_award_1_done"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">在决斗任务中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">在决斗任务中</font>"
+        }
     },
     "weekly_win_get_weekly_duel_mission_award_1": {
         "max_hit": 5,
@@ -962,7 +1018,9 @@
         "next": [
             "close_mission_and_back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认无奖励可领取</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认无奖励可领取</font>"
+        }
     },
     "close_mission_and_back_main_screen": {
         "recognition": "OCR",
@@ -997,7 +1055,9 @@
         "pre_delay": 0,
         "action": "Click",
         "post_delay": 200,
-        "focus": "<font color=\"DeepSkyBlue\">领取决斗任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取决斗任务奖励</font>"
+        }
     },
     "weekly_win_check_daily_duel_mission_recover_award": {
         "recognition": "TemplateMatch",
@@ -1017,7 +1077,9 @@
             "[JumpBack]weekly_win_check_daily_duel_mission_recover_award",
             "weekly_win_check_daily_duel_mission_without_recover_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">追回过期决斗任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">追回过期决斗任务奖励</font>"
+        }
     },
     "weekly_win_check_daily_duel_mission_without_recover_award": {
         "recognition": "TemplateMatch",
@@ -1035,7 +1097,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">没有可追回过期决斗任务奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">没有可追回过期决斗任务奖励</font>"
+        }
     },
     "weekly_win_check_daily_duel_mission_free_recover_award": {
         "recognition": "OCR",
@@ -1063,7 +1127,9 @@
             "weekly_win_check_daily_duel_mission_without_time_card",
             "[JumpBack]weekly_win_check_daily_duel_mission_free_recover_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">有时间卡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">有时间卡</font>"
+        }
     },
     "weekly_win_check_daily_duel_mission_without_time_card": {
         "recognition": "OCR",
@@ -1099,7 +1165,9 @@
             "weekly_win_check_daily_duel_mission_back_fight",
             "[JumpBack]weekly_win_check_no_daily_duel_mission_recover_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认没有可追回过期决斗宝箱</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认没有可追回过期决斗宝箱</font>"
+        }
     },
     "weekly_win_check_daily_duel_mission_back_fight": {
         "recognition": "And",
@@ -1135,7 +1203,9 @@
             "go_to_war_again",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">回到战斗</font>"
+        }
     },
     "weekly_win_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -1154,7 +1224,9 @@
             "ac_entry_mission_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "weekly_win_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -1184,7 +1256,9 @@
             "[JumpBack]go_to_war",
             "weekly_win_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">匹配首胜任务未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">匹配首胜任务未完成</font>"
+        }
     },
     "weekly_win_combo_attack": {
         "pre_delay": 0,

--- a/assets/resource/base/pipeline/auto_battle.json
+++ b/assets/resource/base/pipeline/auto_battle.json
@@ -12,7 +12,7 @@
         "next": [
             "click_attack_2.5s"
         ],
-        "focus": "[color:darkgray]使用一技能[/color]"
+        "focus": "<font color=\"darkgray\">使用一技能</font>"
     },
     "click_skill_2": {
         "pre_delay": 0,
@@ -27,7 +27,7 @@
         "next": [
             "click_attack_2.5s"
         ],
-        "focus": "[color:darkgray]使用二技能[/color]"
+        "focus": "<font color=\"darkgray\">使用二技能</font>"
     },
     "click_Ult_and_attack_3s": {
         "recognition": "DirectHit",
@@ -70,7 +70,7 @@
         "next": [
             "summon_and_roll"
         ],
-        "focus": "[color:darkgray]奥义和普攻[/color]"
+        "focus": "<font color=\"darkgray\">奥义和普攻</font>"
     },
     "click_attack_2.5s": {
         "recognition": "DirectHit",
@@ -90,7 +90,7 @@
         ],
         "duration": 2500,
         "post_delay": 0,
-        "focus": "[color:darkgray]普攻[/color]",
+        "focus": "<font color=\"darkgray\">普攻</font>",
         "$doc": "attack"
     },
     "move_to_left": {
@@ -111,7 +111,7 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "[color:darkgray]向左走[/color]"
+        "focus": "<font color=\"darkgray\">向左走</font>"
     },
     "move_to_right": {
         "recognition": "DirectHit",
@@ -131,7 +131,7 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "[color:darkgray]向右走[/color]"
+        "focus": "<font color=\"darkgray\">向右走</font>"
     },
     "move_to_up": {
         "recognition": "DirectHit",
@@ -151,7 +151,7 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "[color:darkgray]向上走[/color]"
+        "focus": "<font color=\"darkgray\">向上走</font>"
     },
     "move_to_down": {
         "recognition": "DirectHit",
@@ -171,7 +171,7 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "[color:darkgray]向下走[/color]"
+        "focus": "<font color=\"darkgray\">向下走</font>"
     },
     "summon_and_roll": {
         "recognition": "DirectHit",
@@ -211,7 +211,7 @@
             }
         ],
         "post_delay": 0,
-        "focus": "[color:darkgray]通灵或密卷[/color]"
+        "focus": "<font color=\"darkgray\">通灵或密卷</font>"
     },
     "click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/auto_battle.json
+++ b/assets/resource/base/pipeline/auto_battle.json
@@ -12,7 +12,9 @@
         "next": [
             "click_attack_2.5s"
         ],
-        "focus": "<font color=\"darkgray\">使用一技能</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">使用一技能</font>"
+        }
     },
     "click_skill_2": {
         "pre_delay": 0,
@@ -27,7 +29,9 @@
         "next": [
             "click_attack_2.5s"
         ],
-        "focus": "<font color=\"darkgray\">使用二技能</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">使用二技能</font>"
+        }
     },
     "click_Ult_and_attack_3s": {
         "recognition": "DirectHit",
@@ -70,7 +74,9 @@
         "next": [
             "summon_and_roll"
         ],
-        "focus": "<font color=\"darkgray\">奥义和普攻</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">奥义和普攻</font>"
+        }
     },
     "click_attack_2.5s": {
         "recognition": "DirectHit",
@@ -90,7 +96,9 @@
         ],
         "duration": 2500,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">普攻</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">普攻</font>"
+        },
         "$doc": "attack"
     },
     "move_to_left": {
@@ -111,7 +119,9 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">向左走</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">向左走</font>"
+        }
     },
     "move_to_right": {
         "recognition": "DirectHit",
@@ -131,7 +141,9 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">向右走</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">向右走</font>"
+        }
     },
     "move_to_up": {
         "recognition": "DirectHit",
@@ -151,7 +163,9 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">向上走</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">向上走</font>"
+        }
     },
     "move_to_down": {
         "recognition": "DirectHit",
@@ -171,7 +185,9 @@
         ],
         "duration": 500,
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">向下走</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">向下走</font>"
+        }
     },
     "summon_and_roll": {
         "recognition": "DirectHit",
@@ -211,7 +227,9 @@
             }
         ],
         "post_delay": 0,
-        "focus": "<font color=\"darkgray\">通灵或密卷</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"darkgray\">通灵或密卷</font>"
+        }
     },
     "click_All_skill": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/debug.json
+++ b/assets/resource/base/pipeline/debug.json
@@ -15,14 +15,18 @@
         "action": "Shell",
         "cmd": "settings put system show_touches 0",
         "next": "hide_pointer_location",
-        "focus": "关闭触控显示"
+        "focus": {
+            "Node.Action.Starting": "关闭触控显示"
+        }
     },
     "show_touches": {
         "enabled": false,
         "max_hit": 1,
         "action": "Shell",
         "cmd": "settings put system show_touches 1",
-        "focus": "开启触控显示"
+        "focus": {
+            "Node.Action.Starting": "开启触控显示"
+        }
     },
     "set_pointer_location": {
         "next": [
@@ -35,14 +39,18 @@
         "max_hit": 1,
         "action": "Shell",
         "cmd": "settings put system pointer_location 0",
-        "focus": "隐藏指针位置"
+        "focus": {
+            "Node.Action.Starting": "隐藏指针位置"
+        }
     },
     "show_pointer_location": {
         "enabled": false,
         "max_hit": 1,
         "action": "Shell",
         "cmd": "settings put system pointer_location 1",
-        "focus": "显示指针位置"
+        "focus": {
+            "Node.Action.Starting": "显示指针位置"
+        }
     },
     "others_settings": {
         "action": "StopTask"

--- a/assets/resource/base/pipeline/get_aoyi_picture.json
+++ b/assets/resource/base/pipeline/get_aoyi_picture.json
@@ -7,12 +7,16 @@
             "get_aoyi_picture_activity",
             "absence_get_aoyi_picture_interface"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">获取奥义图</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">获取奥义图</font>"
+        }
     },
     "absence_get_aoyi_picture_interface": {
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "<font color=\"DeepSkyBlue\">请在活动界面开启！</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">请在活动界面开启！</font>"
+        }
     },
     "get_aoyi_picture_activity": {
         "recognition": "OCR",
@@ -141,7 +145,9 @@
             "get_aoyi_picture_ok",
             "get_aoyi_picture_challenge_dice_quit"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">奥义图领取成功！</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">奥义图领取成功！</font>"
+        }
     },
     "get_aoyi_picture_ok": {
         "recognition": "OCR",
@@ -163,7 +169,9 @@
             "get_aoyi_picture_challenge_dice_done",
             "get_aoyi_picture_ok"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">你已经领取过这个奥义图了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">你已经领取过这个奥义图了</font>"
+        }
     },
     "3get_aoyi_picture_challenge": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/get_aoyi_picture.json
+++ b/assets/resource/base/pipeline/get_aoyi_picture.json
@@ -7,12 +7,12 @@
             "get_aoyi_picture_activity",
             "absence_get_aoyi_picture_interface"
         ],
-        "focus": "[color:DeepSkyBlue]获取奥义图[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">获取奥义图</font>"
     },
     "absence_get_aoyi_picture_interface": {
         "pre_delay": 0,
         "post_delay": 0,
-        "focus": "[color:DeepSkyBlue]请在活动界面开启！[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">请在活动界面开启！</font>"
     },
     "get_aoyi_picture_activity": {
         "recognition": "OCR",
@@ -141,7 +141,7 @@
             "get_aoyi_picture_ok",
             "get_aoyi_picture_challenge_dice_quit"
         ],
-        "focus": "[color:DeepSkyBlue]奥义图领取成功！[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">奥义图领取成功！</font>"
     },
     "get_aoyi_picture_ok": {
         "recognition": "OCR",
@@ -163,7 +163,7 @@
             "get_aoyi_picture_challenge_dice_done",
             "get_aoyi_picture_ok"
         ],
-        "focus": "[color:DeepSkyBlue]你已经领取过这个奥义图了[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">你已经领取过这个奥义图了</font>"
     },
     "3get_aoyi_picture_challenge": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/konoha_snack_shop.json
+++ b/assets/resource/base/pipeline/konoha_snack_shop.json
@@ -7,7 +7,9 @@
             "konoha_snack_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入木叶小吃店任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入木叶小吃店任务</font>"
+        }
     },
     "konoha_snack_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +37,9 @@
             "[JumpBack]swipes_for_konoha_snack",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入木叶小吃店活动</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入木叶小吃店活动</font>"
+        }
     },
     "swipes_for_konoha_snack": {
         "max_hit": 5,
@@ -63,7 +67,9 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "<font color=\"DeepSkyBlue\">前往木叶小吃店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">前往木叶小吃店</font>"
+        }
     },
     "find_konoha_snack": {
         "recognition": "OCR",
@@ -84,7 +90,9 @@
             "konoha_snack_start",
             "[JumpBack]find_konoha_snack"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">找到木叶小吃店</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">找到木叶小吃店</font>"
+        }
     },
     "konoha_snack_start": {
         "recognition": "OCR",
@@ -108,7 +116,9 @@
             "[JumpBack]konoha_snack_get",
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入投喂游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入投喂游戏</font>"
+        }
     },
     "konoha_snack_hashirma": {
         "recognition": "TemplateMatch",
@@ -136,7 +146,9 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">太好了是柱间,我们有救了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">太好了是柱间,我们有救了</font>"
+        }
     },
     "konoha_snack_high": {
         "recognition": "TemplateMatch",
@@ -164,7 +176,9 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">火之高兴</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">火之高兴</font>"
+        }
     },
     "konoha_snack_low": {
         "recognition": "TemplateMatch",
@@ -192,7 +206,9 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">过牌</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">过牌</font>"
+        }
     },
     "konoha_snack_mid": {
         "recognition": "TemplateMatch",
@@ -220,7 +236,9 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">忧郁蓝调</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">忧郁蓝调</font>"
+        }
     },
     "konoha_snack_get": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/konoha_snack_shop.json
+++ b/assets/resource/base/pipeline/konoha_snack_shop.json
@@ -7,7 +7,7 @@
             "konoha_snack_entry",
             "[JumpBack]back_main_screen"
         ],
-        "focus": "[color:DeepSkyBlue]进入木叶小吃店任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入木叶小吃店任务</font>"
     },
     "konoha_snack_entry": {
         "recognition": "TemplateMatch",
@@ -35,7 +35,7 @@
             "[JumpBack]swipes_for_konoha_snack",
             "[JumpBack]back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入木叶小吃店活动[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入木叶小吃店活动</font>"
     },
     "swipes_for_konoha_snack": {
         "max_hit": 5,
@@ -63,7 +63,7 @@
         ],
         "duration": 200,
         "post_delay": 700,
-        "focus": "[color:DeepSkyBlue]前往木叶小吃店[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">前往木叶小吃店</font>"
     },
     "find_konoha_snack": {
         "recognition": "OCR",
@@ -84,7 +84,7 @@
             "konoha_snack_start",
             "[JumpBack]find_konoha_snack"
         ],
-        "focus": "[color:DeepSkyBlue]找到木叶小吃店[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">找到木叶小吃店</font>"
     },
     "konoha_snack_start": {
         "recognition": "OCR",
@@ -108,7 +108,7 @@
             "[JumpBack]konoha_snack_get",
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]进入投喂游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入投喂游戏</font>"
     },
     "konoha_snack_hashirma": {
         "recognition": "TemplateMatch",
@@ -136,7 +136,7 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "[color:DeepSkyBlue]太好了是柱间,我们有救了[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">太好了是柱间,我们有救了</font>"
     },
     "konoha_snack_high": {
         "recognition": "TemplateMatch",
@@ -164,7 +164,7 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "[color:DeepSkyBlue]火之高兴[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">火之高兴</font>"
     },
     "konoha_snack_low": {
         "recognition": "TemplateMatch",
@@ -192,7 +192,7 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "[color:DeepSkyBlue]过牌[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">过牌</font>"
     },
     "konoha_snack_mid": {
         "recognition": "TemplateMatch",
@@ -220,7 +220,7 @@
             "konoha_snack_get",
             "[JumpBack]konoha_snack_start"
         ],
-        "focus": "[color:DeepSkyBlue]忧郁蓝调[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">忧郁蓝调</font>"
     },
     "konoha_snack_get": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/mini_game.json
+++ b/assets/resource/base/pipeline/mini_game.json
@@ -1,6 +1,6 @@
 {
     "mini_game": {
         "next": "treasure_gathering_trial_award",
-        "focus": "[color:DeepSkyBlue]进入小游戏[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入小游戏</font>"
     }
 }

--- a/assets/resource/base/pipeline/mini_game.json
+++ b/assets/resource/base/pipeline/mini_game.json
@@ -1,6 +1,8 @@
 {
     "mini_game": {
         "next": "treasure_gathering_trial_award",
-        "focus": "<font color=\"DeepSkyBlue\">进入小游戏</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入小游戏</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/practice_place_shugyou_no_michi.json
+++ b/assets/resource/base/pipeline/practice_place_shugyou_no_michi.json
@@ -8,7 +8,7 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入修行之路[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入修行之路</font>"
     },
     "go_into_shugyou_no_michi_by_guide": {
         "recognition": "Or",
@@ -95,7 +95,7 @@
             "confirm_train_road_sweep",
             "[JumpBack]train_road_unsweep"
         ],
-        "focus": "[color:DeepSkyBlue]修行之路未扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">修行之路未扫荡</font>"
     },
     "train_road_sweeping": {
         "recognition": "OCR",
@@ -111,7 +111,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]修行之路扫荡中[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">修行之路扫荡中</font>"
     },
     "train_road_award": {
         "recognition": "OCR",
@@ -131,7 +131,7 @@
         "next": [
             "confirm_train_road_award"
         ],
-        "focus": "[color:DeepSkyBlue]领取修行之路奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">领取修行之路奖励</font>"
     },
     "confirm_train_road_award": {
         "recognition": "OCR",
@@ -151,7 +151,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]确认修行之路奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认修行之路奖励</font>"
     },
     "train_road_unreset": {
         "max_hit": 5,
@@ -173,7 +173,7 @@
             "confirm_train_road_reset",
             "train_road_unreset"
         ],
-        "focus": "[color:DeepSkyBlue]重置修行之路[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">重置修行之路</font>"
     },
     "above_kage_confirm_train_road_reset": {
         "recognition": "TemplateMatch",
@@ -192,7 +192,7 @@
         "next": [
             "above_kage_confirm_train_road_award"
         ],
-        "focus": "[color:DeepSkyBlue]修行之路超影重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">修行之路超影重置</font>"
     },
     "above_kage_confirm_train_road_award": {
         "recognition": "TemplateMatch",
@@ -211,7 +211,7 @@
         "next": [
             "confirm_train_road_award"
         ],
-        "focus": "[color:DeepSkyBlue]确认修行之路超影重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认修行之路超影重置</font>"
     },
     "confirm_train_road_reset": {
         "recognition": "TemplateMatch",
@@ -232,7 +232,7 @@
             "above_kage_confirm_train_road_reset",
             "confirm_train_road_reset"
         ],
-        "focus": "[color:DeepSkyBlue]确认修行之路重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认修行之路重置</font>"
     },
     "confirm_train_road_sweep": {
         "recognition": "OCR",
@@ -253,7 +253,7 @@
             "without_confirm_train_road_sweep",
             "confirm_train_road_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]确认修行之路扫荡[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认修行之路扫荡</font>"
     },
     "without_confirm_train_road_sweep": {
         "recognition": "OCR",
@@ -288,7 +288,7 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]修行之路已完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">修行之路已完成</font>"
     },
     "shugyou_no_michi_auto_push": {
         "recognition": "TemplateMatch",
@@ -668,6 +668,6 @@
             "train_road_entry",
             "train_road_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]修行之路未完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">修行之路未完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/practice_place_shugyou_no_michi.json
+++ b/assets/resource/base/pipeline/practice_place_shugyou_no_michi.json
@@ -8,7 +8,9 @@
             "[JumpBack]open_ninja_guide",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入修行之路</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入修行之路</font>"
+        }
     },
     "go_into_shugyou_no_michi_by_guide": {
         "recognition": "Or",
@@ -50,7 +52,9 @@
             "train_road_entry",
             "[JumpBack]ninja_guide_to_funtion_retry"
         ],
-        "focus": "进入修行之路"
+        "focus": {
+            "Node.Action.Starting": "进入修行之路"
+        }
     },
     "train_road_entry": {
         "recognition": "OCR",
@@ -95,7 +99,9 @@
             "confirm_train_road_sweep",
             "[JumpBack]train_road_unsweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">修行之路未扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">修行之路未扫荡</font>"
+        }
     },
     "train_road_sweeping": {
         "recognition": "OCR",
@@ -111,7 +117,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">修行之路扫荡中</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">修行之路扫荡中</font>"
+        }
     },
     "train_road_award": {
         "recognition": "OCR",
@@ -131,7 +139,9 @@
         "next": [
             "confirm_train_road_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">领取修行之路奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">领取修行之路奖励</font>"
+        }
     },
     "confirm_train_road_award": {
         "recognition": "OCR",
@@ -151,7 +161,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认修行之路奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认修行之路奖励</font>"
+        }
     },
     "train_road_unreset": {
         "max_hit": 5,
@@ -173,7 +185,9 @@
             "confirm_train_road_reset",
             "train_road_unreset"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">重置修行之路</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">重置修行之路</font>"
+        }
     },
     "above_kage_confirm_train_road_reset": {
         "recognition": "TemplateMatch",
@@ -192,7 +206,9 @@
         "next": [
             "above_kage_confirm_train_road_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">修行之路超影重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">修行之路超影重置</font>"
+        }
     },
     "above_kage_confirm_train_road_award": {
         "recognition": "TemplateMatch",
@@ -211,7 +227,9 @@
         "next": [
             "confirm_train_road_award"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认修行之路超影重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认修行之路超影重置</font>"
+        }
     },
     "confirm_train_road_reset": {
         "recognition": "TemplateMatch",
@@ -232,7 +250,9 @@
             "above_kage_confirm_train_road_reset",
             "confirm_train_road_reset"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认修行之路重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认修行之路重置</font>"
+        }
     },
     "confirm_train_road_sweep": {
         "recognition": "OCR",
@@ -253,7 +273,9 @@
             "without_confirm_train_road_sweep",
             "confirm_train_road_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认修行之路扫荡</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认修行之路扫荡</font>"
+        }
     },
     "without_confirm_train_road_sweep": {
         "recognition": "OCR",
@@ -288,7 +310,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">修行之路已完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">修行之路已完成</font>"
+        }
     },
     "shugyou_no_michi_auto_push": {
         "recognition": "TemplateMatch",
@@ -333,7 +357,9 @@
         ],
         "action": "Click",
         "post_delay": 0,
-        "focus": "传送到前方关卡"
+        "focus": {
+            "Node.Action.Starting": "传送到前方关卡"
+        }
     },
     "shugyou_no_michi_go_to_war": {
         "recognition": "TemplateMatch",
@@ -356,7 +382,9 @@
             "shugyou_no_michi_go_to_war",
             "shugyou_no_michi_try_go_to_war"
         ],
-        "focus": "进入战斗"
+        "focus": {
+            "Node.Action.Starting": "进入战斗"
+        }
     },
     "shugyou_no_michi_go_to_war_done": {
         "recognition": "OCR",
@@ -374,7 +402,9 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "修行之路全部关卡已经完成"
+        "focus": {
+            "Node.Action.Starting": "修行之路全部关卡已经完成"
+        }
     },
     "shugyou_no_michi_try_go_to_war": {
         "recognition": "TemplateMatch",
@@ -470,7 +500,9 @@
             "wait_for_battle_again",
             "shugyou_no_michi_quit"
         ],
-        "focus": "没有检测到自动战斗"
+        "focus": {
+            "Node.Action.Starting": "没有检测到自动战斗"
+        }
     },
     "click_auto_battle": {
         "recognition": "Or",
@@ -530,7 +562,9 @@
             "wait_for_battle_again",
             "shugyou_no_michi_quit"
         ],
-        "focus": "开启自动战斗"
+        "focus": {
+            "Node.Action.Starting": "开启自动战斗"
+        }
     },
     "fail_in_shugyou_no_michi": {
         "recognition": "TemplateMatch",
@@ -548,7 +582,9 @@
         "next": [
             "shugyou_no_michi_quit"
         ],
-        "focus": "战斗失败"
+        "focus": {
+            "Node.Action.Starting": "战斗失败"
+        }
     },
     "shugyou_no_michi_quit": {
         "recognition": "OCR",
@@ -668,6 +704,8 @@
             "train_road_entry",
             "train_road_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">修行之路未完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">修行之路未完成</font>"
+        }
     }
 }

--- a/assets/resource/base/pipeline/practice_place_survival_challenge.json
+++ b/assets/resource/base/pipeline/practice_place_survival_challenge.json
@@ -7,7 +7,7 @@
             "[JumpBack]award_center_enter",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "[color:DeepSkyBlue]进入生存挑战任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战任务</font>"
     },
     "survival_challenge_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +26,7 @@
             "survival_challenge_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "[color:DeepSkyBlue]检测是否已在奖励中心[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
     },
     "survival_challenge_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -52,7 +52,7 @@
             "survival_challenge_in_survival_challenge",
             "survival_challenge_ac_entry_undone"
         ],
-        "focus": "[color:DeepSkyBlue]进入生存挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战</font>"
     },
     "survival_challenge_in_survival_challenge": {
         "recognition": "TemplateMatch",
@@ -85,7 +85,7 @@
         "next": [
             "survival_challenge_confirm_above_kage"
         ],
-        "focus": "[color:DeepSkyBlue]生存挑战超影服务触发[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战超影服务触发</font>"
     },
     "survival_challenge_confirm_above_kage": {
         "recognition": "OCR",
@@ -151,7 +151,7 @@
         "post_wait_freezes": 200,
         "post_delay": 0,
         "next": "survival_challenge_yesterday_award_1",
-        "focus": "[color:DeepSkyBlue]尝试领取昨日奖励[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">尝试领取昨日奖励</font>"
     },
     "survival_challenge_yesterday_award_1": {
         "recognition": "TemplateMatch",
@@ -189,7 +189,7 @@
             "survival_challenge_above_kage",
             "start_survival_challenge_sweep"
         ],
-        "focus": "[color:DeepSkyBlue]生存挑战已重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战已重置</font>"
     },
     "survival_challenge_reset_undone": {
         "recognition": "TemplateMatch",
@@ -213,7 +213,7 @@
         "next": [
             "confirm_survival_challenge_reset"
         ],
-        "focus": "[color:DeepSkyBlue]生存挑战未重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战未重置</font>"
     },
     "confirm_survival_challenge_reset": {
         "recognition": "TemplateMatch",
@@ -232,7 +232,7 @@
         "next": [
             "survival_challenge_confirm_tp"
         ],
-        "focus": "[color:DeepSkyBlue]确认生存挑战重置[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认生存挑战重置</font>"
     },
     "survival_challenge_confirm_tp": {
         "recognition": "TemplateMatch",
@@ -250,7 +250,7 @@
         "next": [
             "survival_challenge_confirm_tp_1"
         ],
-        "focus": "[color:DeepSkyBlue]生存挑战传送[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战传送</font>"
     },
     "survival_challenge_confirm_tp_1": {
         "recognition": "TemplateMatch",
@@ -308,7 +308,7 @@
         "on_error": [
             "retry_failed"
         ],
-        "focus": "[color:DeepSkyBlue]进入生存挑战扫荡任务[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战扫荡任务</font>"
     },
     "check_survival_challenge_done": {
         "recognition": "OCR",
@@ -340,7 +340,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]扫荡券不足[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">扫荡券不足</font>"
     },
     "survival_challenge_sweep_ready": {
         "recognition": "OCR",
@@ -386,7 +386,7 @@
             "survival_challenge_sweep_confirm",
             "survival_challenge_ninja_select_confirm"
         ],
-        "focus": "[color:DeepSkyBlue]确认进行生存挑战[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">确认进行生存挑战</font>"
     },
     "survival_challenge_ninja_select_confirm": {
         "recognition": "TemplateMatch",
@@ -458,7 +458,7 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]确认生存挑战挑战卷提示[/color]",
+        "focus": "<font color=\"DeepSkyBlue\">确认生存挑战挑战卷提示</font>",
         "$doc": "这里设置了post_wait_freezes,所以timeout可以调的很短"
     },
     "survival_challenge_check_done": {
@@ -526,7 +526,7 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "[color:DeepSkyBlue]生存挑战卷用完了[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战卷用完了</font>"
     },
     "wait_for_survival_challenge_sweep_complete": {
         "recognition": "TemplateMatch",
@@ -540,6 +540,6 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "[color:DeepSkyBlue]生存挑战扫荡完成[/color]"
+        "focus": "<font color=\"DeepSkyBlue\">生存挑战扫荡完成</font>"
     }
 }

--- a/assets/resource/base/pipeline/practice_place_survival_challenge.json
+++ b/assets/resource/base/pipeline/practice_place_survival_challenge.json
@@ -7,7 +7,9 @@
             "[JumpBack]award_center_enter",
             "[JumpBack]back_main_screen_before_task"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入生存挑战任务</font>"
+        }
     },
     "survival_challenge_in_center_enter": {
         "recognition": "TemplateMatch",
@@ -26,7 +28,9 @@
             "survival_challenge_ac_done",
             "[JumpBack]swipe_for_award_center_find"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">检测是否已在奖励中心</font>"
+        }
     },
     "survival_challenge_ac_entry_undone": {
         "recognition": "TemplateMatch",
@@ -52,7 +56,9 @@
             "survival_challenge_in_survival_challenge",
             "survival_challenge_ac_entry_undone"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入生存挑战</font>"
+        }
     },
     "survival_challenge_in_survival_challenge": {
         "recognition": "TemplateMatch",
@@ -85,7 +91,9 @@
         "next": [
             "survival_challenge_confirm_above_kage"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战超影服务触发</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战超影服务触发</font>"
+        }
     },
     "survival_challenge_confirm_above_kage": {
         "recognition": "OCR",
@@ -151,7 +159,9 @@
         "post_wait_freezes": 200,
         "post_delay": 0,
         "next": "survival_challenge_yesterday_award_1",
-        "focus": "<font color=\"DeepSkyBlue\">尝试领取昨日奖励</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">尝试领取昨日奖励</font>"
+        }
     },
     "survival_challenge_yesterday_award_1": {
         "recognition": "TemplateMatch",
@@ -189,7 +199,9 @@
             "survival_challenge_above_kage",
             "start_survival_challenge_sweep"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战已重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战已重置</font>"
+        }
     },
     "survival_challenge_reset_undone": {
         "recognition": "TemplateMatch",
@@ -213,7 +225,9 @@
         "next": [
             "confirm_survival_challenge_reset"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战未重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战未重置</font>"
+        }
     },
     "confirm_survival_challenge_reset": {
         "recognition": "TemplateMatch",
@@ -232,7 +246,9 @@
         "next": [
             "survival_challenge_confirm_tp"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认生存挑战重置</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认生存挑战重置</font>"
+        }
     },
     "survival_challenge_confirm_tp": {
         "recognition": "TemplateMatch",
@@ -250,7 +266,9 @@
         "next": [
             "survival_challenge_confirm_tp_1"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战传送</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战传送</font>"
+        }
     },
     "survival_challenge_confirm_tp_1": {
         "recognition": "TemplateMatch",
@@ -308,7 +326,9 @@
         "on_error": [
             "retry_failed"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">进入生存挑战扫荡任务</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入生存挑战扫荡任务</font>"
+        }
     },
     "check_survival_challenge_done": {
         "recognition": "OCR",
@@ -340,7 +360,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">扫荡券不足</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">扫荡券不足</font>"
+        }
     },
     "survival_challenge_sweep_ready": {
         "recognition": "OCR",
@@ -386,7 +408,9 @@
             "survival_challenge_sweep_confirm",
             "survival_challenge_ninja_select_confirm"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认进行生存挑战</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认进行生存挑战</font>"
+        }
     },
     "survival_challenge_ninja_select_confirm": {
         "recognition": "TemplateMatch",
@@ -458,7 +482,9 @@
         "on_error": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">确认生存挑战挑战卷提示</font>",
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">确认生存挑战挑战卷提示</font>"
+        },
         "$doc": "这里设置了post_wait_freezes,所以timeout可以调的很短"
     },
     "survival_challenge_check_done": {
@@ -526,7 +552,9 @@
         "pre_delay": 0,
         "post_delay": 0,
         "next": "back_main_screen_and_stop",
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战卷用完了</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战卷用完了</font>"
+        }
     },
     "wait_for_survival_challenge_sweep_complete": {
         "recognition": "TemplateMatch",
@@ -540,6 +568,8 @@
         "next": [
             "back_main_screen_and_stop"
         ],
-        "focus": "<font color=\"DeepSkyBlue\">生存挑战扫荡完成</font>"
+        "focus": {
+            "Node.Action.Starting": "<font color=\"DeepSkyBlue\">生存挑战扫荡完成</font>"
+        }
     }
 }

--- a/assets/tasks/ninjaGuide.json
+++ b/assets/tasks/ninjaGuide.json
@@ -421,7 +421,7 @@
                             "custom_action_param": {
                                 "entry_name": "忍术对战"
                             },
-                            "focus": "[color:DeepSkyBlue]进入忍术对战[/color]"
+                            "focus": "<font color=\"DeepSkyBlue\">进入忍术对战</font>"
                         }
                     }
                 },
@@ -432,7 +432,7 @@
                             "custom_action_param": {
                                 "entry_name": "段位赛"
                             },
-                            "focus": "[color:DeepSkyBlue]进入段位赛[/color]"
+                            "focus": "<font color=\"DeepSkyBlue\">进入段位赛</font>"
                         },
                         "ninja_guide_find_funtion_entry": {
                             "expected": [

--- a/assets/tasks/ninjaGuide.json
+++ b/assets/tasks/ninjaGuide.json
@@ -421,7 +421,9 @@
                             "custom_action_param": {
                                 "entry_name": "忍术对战"
                             },
-                            "focus": "<font color=\"DeepSkyBlue\">进入忍术对战</font>"
+                            "focus": {
+                                "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入忍术对战</font>"
+                            }
                         }
                     }
                 },
@@ -432,7 +434,9 @@
                             "custom_action_param": {
                                 "entry_name": "段位赛"
                             },
-                            "focus": "<font color=\"DeepSkyBlue\">进入段位赛</font>"
+                            "focus": {
+                                "Node.Action.Starting": "<font color=\"DeepSkyBlue\">进入段位赛</font>"
+                            }
                         },
                         "ninja_guide_find_funtion_entry": {
                             "expected": [

--- a/assets/tasks/pointRace.json
+++ b/assets/tasks/pointRace.json
@@ -65,7 +65,9 @@
                             "next": [
                                 "back_main_screen_and_stop"
                             ],
-                            "focus": "<font color=\"DeepSkyBlue\">积分赛失败</font>"
+                            "focus": {
+                                "Node.Action.Starting": "<font color=\"DeepSkyBlue\">积分赛失败</font>"
+                            }
                         }
                     }
                 },

--- a/assets/tasks/pointRace.json
+++ b/assets/tasks/pointRace.json
@@ -65,7 +65,7 @@
                             "next": [
                                 "back_main_screen_and_stop"
                             ],
-                            "focus": "[color:DeepSkyBlue]积分赛失败[/color]"
+                            "focus": "<font color=\"DeepSkyBlue\">积分赛失败</font>"
                         }
                     }
                 },


### PR DESCRIPTION
## Summary
- 将 718 处 Pipeline 与任务 override 中的 focus 私有着色标记统一迁移为 HTML4 `<font color="...">`
- 保持颜色与文案不变，仅替换标记语法

## Test
- `pnpm check:maa`
- `pnpm exec prettier --check assets/resource/base/pipeline/*.json assets/tasks/*.json`
- `git diff --check`