### PR TITLE
ci:区分测试包应用名称和包名

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -78,6 +78,25 @@ jobs:
       - name: Prepare PI tree
         run: python tools/prepare_android_pi.py
 
+      # Only this runner's checkout is modified; the reusable release workflow starts clean.
+      - name: Use internal-test app identity
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          profile = Path("Android/profile.yaml")
+          text = profile.read_text()
+          replacements = {
+              "  id: man\n": "  id: man.ci\n",
+              "  label: MaaAutoNaruto\n": "  label: MaaAutoNaruto 内测版\n",
+          }
+          for old, new in replacements.items():
+              if text.count(old) != 1:
+                  raise SystemExit(f"expected exactly one {old.strip()!r} in {profile}")
+              text = text.replace(old, new)
+          profile.write_text(text)
+          PY
+
       - name: Fetch MaaFramework native libs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 变更
- Actions debug 构建在 runner 内临时修改 PI profile
- 测试包使用 `com.aliothmoon.maafw.man.ci` 和 `MaaAutoNaruto 内测版`
- release workflow 独立 checkout，仍使用正式包身份

## 验证
- 检查 workflow YAML 可解析
- 验证 profile 临时替换生成预期 CI 身份
- 验证默认 Gradle 配置仍为 `com.aliothmoon.maafw.man`