### PR TITLE
ci:Unix产物改用tar.gz打包

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
     paths:
-      - ".github/workflows/check.yml"
+      - ".github/workflows/*.yml"
       - "assets/**"
       - "**.py"
       - "pyproject.toml"
@@ -13,7 +13,7 @@ on:
     branches:
       - "**"
     paths:
-      - ".github/workflows/check.yml"
+      - ".github/workflows/*.yml"
       - "assets/**"
       - "**.py"
       - "pyproject.toml"

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,6 +10,7 @@ on:
       - "**"
     paths:
       - ".github/workflows/install.yml"
+      - ".github/workflows/release.yml"
       - "assets/**"
       - "**.py"
   pull_request:
@@ -17,6 +18,7 @@ on:
       - "**"
     paths:
       - ".github/workflows/install.yml"
+      - ".github/workflows/release.yml"
       - "assets/**"
       - "**.py"
   workflow_dispatch:

--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: MirrorChyan/uploading-action@v1
         with:
           filetype: latest-release
-          filename: "MaaAutoNaruto-${{ matrix.os }}-${{ matrix.arch }}-*.zip"
+          filename: "MaaAutoNaruto-${{ matrix.os }}-${{ matrix.arch }}-*.${{ matrix.os == 'macos' && 'tar.gz' || 'zip' }}"
           mirrorchyan_rid: MaaAutoNaruto
           tag: ${{ inputs.tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,11 @@ jobs:
           shopt -s nullglob
           for directory in release-assets/desktop/*; do
             name=$(basename "$directory")
-            (cd "$directory" && zip -r "../../../$name.zip" .)
+            if [[ "$name" == MaaAutoNaruto-macos-* ]]; then
+              (cd "$directory" && tar -czf "../../../$name.tar.gz" .)
+            else
+              (cd "$directory" && zip -r "../../../$name.zip" .)
+            fi
           done
 
       - name: Detect prerelease
@@ -134,6 +138,7 @@ jobs:
           overwrite_files: true
           fail_on_unmatched_files: true
           files: |
+            MaaAutoNaruto-*.tar.gz
             MaaAutoNaruto-*.zip
             release-assets/android/*.apk
 


### PR DESCRIPTION
## 变更
- macOS/Linux 发布产物改用 tar.gz 打包，保留可执行文件权限
- Windows 产物继续使用 zip
- 同步调整 GitHub Release 与 MirrorChyan 的文件匹配规则
- workflow 变更会触发检查，release workflow 变更会触发桌面构建

## 验证
- git diff --check
- actionlint（本次修改无报错；既有 workflow 仍有 unrelated shellcheck 提示）
- 完整 install 构建矩阵通过