### PR TITLE
ci:Linux产物改用tar.gz打包

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: MirrorChyan/uploading-action@v1
         with:
           filetype: latest-release
-          filename: "MaaAutoNaruto-${{ matrix.os }}-${{ matrix.arch }}-*.${{ matrix.os == 'macos' && 'tar.gz' || 'zip' }}"
+          filename: "MaaAutoNaruto-${{ matrix.os }}-${{ matrix.arch }}-*.${{ (matrix.os == 'macos' || matrix.os == 'linux') && 'tar.gz' || 'zip' }}"
           mirrorchyan_rid: MaaAutoNaruto
           tag: ${{ inputs.tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           shopt -s nullglob
           for directory in release-assets/desktop/*; do
             name=$(basename "$directory")
-            if [[ "$name" == MaaAutoNaruto-macos-* ]]; then
+            if [[ "$name" == MaaAutoNaruto-macos-* || "$name" == MaaAutoNaruto-linux-* ]]; then
               (cd "$directory" && tar -czf "../../../$name.tar.gz" .)
             else
               (cd "$directory" && zip -r "../../../$name.zip" .)


### PR DESCRIPTION
## 变更
- Linux 发布产物与 macOS 一致，改用 tar.gz 打包，保留可执行文件权限
- Windows 产物继续使用 zip
- 同步调整 MirrorChyan 的 Linux 文件匹配规则

## 验证
- git diff --check
- actionlint（本次修改无报错；既有 workflow 仍有 unrelated shellcheck 提示）